### PR TITLE
Disconnected client crashes

### DIFF
--- a/mod/Jailbreak.Teams/Queue/QueueBehavior.cs
+++ b/mod/Jailbreak.Teams/Queue/QueueBehavior.cs
@@ -46,6 +46,9 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
 
 	public bool TryEnterQueue(CCSPlayerController player)
 	{
+		if (!player.IsReal())
+			return false;
+
 		if (player.GetTeam() == CsTeam.CounterTerrorist)
 			return false;
 
@@ -59,6 +62,9 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
 
 	public bool TryExitQueue(CCSPlayerController player)
 	{
+		if (!player.IsReal())
+			return false;
+
 		var state = _state.Get(player);
 		state.InQueue = false;
 		state.IsGuard = false;
@@ -68,7 +74,9 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
 
 	public bool TryPop(int count)
 	{
-		var queue = Queue.ToList();
+		var queue = Queue
+			.Where(player => player.IsReal())
+			.ToList();
 
 		if (queue.Count <= count)
 		{
@@ -91,9 +99,11 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
 	public bool TryPush(int count)
 	{
 		var players = Utilities.GetPlayers()
+			.Where(player => player.IsReal())
 			.Where(player => player.GetTeam() == CsTeam.CounterTerrorist)
 			.Shuffle(Random.Shared)
 			.ToList();
+
 		_logger.LogInformation("[Queue] Push requested {@Count} out of {@GuardCount}", count, players.Count);
 
 		for (int i = 0; i < Math.Min(count, players.Count); i++)
@@ -176,7 +186,7 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
 		var player = ev.Userid;
 		if (!player.IsReal())
 			return HookResult.Continue;
-		
+
 		var state = _state.Get(ev.Userid);
 
 		if (player.GetTeam() == CsTeam.CounterTerrorist && !state.IsGuard)

--- a/public/Jailbreak.Formatting/Extensions/ViewExtensions.cs
+++ b/public/Jailbreak.Formatting/Extensions/ViewExtensions.cs
@@ -3,6 +3,7 @@ using CounterStrikeSharp.API.Core;
 
 using Jailbreak.Formatting.Base;
 using Jailbreak.Formatting.Core;
+using Jailbreak.Public.Extensions;
 
 namespace Jailbreak.Formatting.Extensions;
 
@@ -22,40 +23,52 @@ public static class ViewExtensions
 
 	public static IView ToPlayerConsole(this IView view, CCSPlayerController player)
 	{
-		var writer = view.ToWriter();
+		if (player.IsReal())
+		{
+			var writer = view.ToWriter();
 
-		foreach (string writerLine in writer.Plain)
-			player.PrintToConsole(writerLine);
+			foreach (string writerLine in writer.Plain)
+				player.PrintToConsole(writerLine);
+		}
 
 		return view;
 	}
 
 	public static IView ToPlayerChat(this IView view, CCSPlayerController player)
 	{
-		var writer = view.ToWriter();
+		if (player.IsReal())
+		{
+			var writer = view.ToWriter();
 
-		foreach (string writerLine in writer.Chat)
-			player.PrintToChat(writerLine);
+			foreach (string writerLine in writer.Chat)
+				player.PrintToChat(writerLine);
+		}
 
 		return view;
 	}
 
 	public static IView ToPlayerCenter(this IView view, CCSPlayerController player)
 	{
-		var writer = view.ToWriter();
-		var merged = string.Join('\n', writer.Plain);
+		if (player.IsReal())
+		{
+			var writer = view.ToWriter();
+			var merged = string.Join('\n', writer.Plain);
 
-		player.PrintToCenter(merged);
+			player.PrintToCenter(merged);
+		}
 
 		return view;
 	}
 
 	public static IView ToPlayerCenterHtml(this IView view, CCSPlayerController player)
 	{
-		var writer = view.ToWriter();
-		var merged = string.Join('\n', writer.Panorama);
+		if (player.IsReal())
+		{
+			var writer = view.ToWriter();
+			var merged = string.Join('\n', writer.Panorama);
 
-		player.PrintToCenterHtml(merged);
+			player.PrintToCenterHtml(merged);
+		}
 
 		return view;
 	}

--- a/src/Jailbreak.Generic/PlayerState/Behaviors/GlobalStateTracker.cs
+++ b/src/Jailbreak.Generic/PlayerState/Behaviors/GlobalStateTracker.cs
@@ -23,4 +23,16 @@ public class GlobalStateTracker : BaseStateTracker, IPluginBehavior
 		Reset(ev.Userid);
 		return HookResult.Continue;
 	}
+
+	/// <summary>
+	/// Reset all global states when a new game starts
+	/// </summary>
+	/// <param name="ev"></param>
+	/// <param name="info"></param>
+	/// <returns></returns>
+	public HookResult OnGameEnd(EventGameEnd ev, GameEventInfo info)
+	{
+		ResetAll();
+		return HookResult.Continue;
+	}
 }


### PR DESCRIPTION
When a client is disconnected, and `ClientPrintF` is invoked, libengine will try and dereference a null private field and slip in a puddle of poo.

This PR aims to remove some edge cases where disconnected players can be touched by the plugin code. This is not extensive as of yet, just some low-hanging fruit.