### PR TITLE
Fix prisoners joining guard using auto select

### DIFF
--- a/mod/Jailbreak.Teams/Queue/QueueBehavior.cs
+++ b/mod/Jailbreak.Teams/Queue/QueueBehavior.cs
@@ -1,4 +1,4 @@
-﻿using CounterStrikeSharp.API;
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
@@ -167,6 +167,16 @@ public class QueueBehavior : IGuardQueue, IPluginBehavior
         //	Player is attempting to join CT and is not a guard?
         //	If so, stop them!!
         if ((CsTeam)team == CsTeam.CounterTerrorist && !state.IsGuard)
+        {
+            _notifications.ATTEMPT_TO_JOIN_FROM_TEAM_MENU
+                .ToPlayerChat(invoked)
+                .ToPlayerCenter(invoked);
+
+            return HookResult.Stop;
+        }
+
+        // Prisoner attempted to use auto-select, cancel the action.
+        if ((CsTeam)team == CsTeam.None && invoked.GetTeam() == CsTeam.Terrorist)
         {
             _notifications.ATTEMPT_TO_JOIN_FROM_TEAM_MENU
                 .ToPlayerChat(invoked)


### PR DESCRIPTION
Added a check for the None team, prevent action if that team is selected. Unaware if it affects anything other than auto select. I don't think spectators using auto select was ever an issue to begin with either.