### PR TITLE
Special Treatment

### DIFF
--- a/lang/Jailbreak.English/Warden/SpecialTreatmentNotifications.cs
+++ b/lang/Jailbreak.English/Warden/SpecialTreatmentNotifications.cs
@@ -1,0 +1,38 @@
+﻿using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+
+using Jailbreak.Formatting.Base;
+using Jailbreak.Formatting.Core;
+using Jailbreak.Formatting.Logistics;
+using Jailbreak.Formatting.Objects;
+using Jailbreak.Formatting.Views;
+
+namespace Jailbreak.English.Warden;
+
+public class SpecialTreatmentNotifications : ISpecialTreatmentNotifications, ILanguage<Formatting.Languages.English>
+{
+	public static FormatObject PREFIX = new HiddenFormatObject( $" {ChatColors.Lime}[{ChatColors.Green}ST{ChatColors.Lime}]" )
+	{
+		//	Hide in panorama and center text
+		Plain = false,
+		Panorama = false,
+		Chat = true,
+	};
+
+	public IView GRANTED =>
+		new SimpleView { PREFIX, "You now have special treatment!" };
+
+	public IView REVOKED =>
+		new SimpleView { PREFIX, "Your special treatment was removed" };
+
+	public IView GRANTED_TO(CCSPlayerController player)
+	{
+		return new SimpleView { PREFIX, player, "now has Special Treatment!" };
+	}
+
+	public IView REVOKED_FROM(CCSPlayerController player)
+	{
+		return new SimpleView { PREFIX, player, "no longer has Special Treatment." };
+	}
+
+}

--- a/mod/Jailbreak.Warden/Commands/SpecialTreatmentCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/SpecialTreatmentCommandsBehavior.cs
@@ -1,0 +1,17 @@
+﻿using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Commands;
+
+namespace Jailbreak.Warden.Commands;
+
+public class SpecialTreatmentCommandsBehavior
+{
+
+	[ConsoleCommand("css_treat", "Grant or revoke special treatment from a player")]
+	[ConsoleCommand("css_st", "Grant or revoke special treatment from a player")]
+	[CommandHelper(0, "css_st / css_treat <player>", CommandUsage.CLIENT_ONLY)]
+	public void Command_Toggle(CCSPlayerController? player, CommandInfo command)
+	{
+
+	}
+}

--- a/mod/Jailbreak.Warden/Commands/SpecialTreatmentCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/SpecialTreatmentCommandsBehavior.cs
@@ -1,17 +1,78 @@
 ﻿using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Utils;
+
+using Jailbreak.Formatting.Extensions;
+using Jailbreak.Formatting.Views;
+using Jailbreak.Public.Behaviors;
+using Jailbreak.Public.Mod.Warden;
 
 namespace Jailbreak.Warden.Commands;
 
-public class SpecialTreatmentCommandsBehavior
+public class SpecialTreatmentCommandsBehavior : IPluginBehavior
 {
+
+	private IWardenService _warden;
+	private ISpecialTreatmentService _specialTreatment;
+
+	private IGenericCommandNotifications _generic;
+	private ISpecialTreatmentNotifications _notifications;
+
+	public SpecialTreatmentCommandsBehavior(IWardenService warden, ISpecialTreatmentService specialTreatment, IGenericCommandNotifications generic, ISpecialTreatmentNotifications notifications)
+	{
+		_warden = warden;
+		_specialTreatment = specialTreatment;
+		_generic = generic;
+		_notifications = notifications;
+	}
 
 	[ConsoleCommand("css_treat", "Grant or revoke special treatment from a player")]
 	[ConsoleCommand("css_st", "Grant or revoke special treatment from a player")]
-	[CommandHelper(0, "css_st / css_treat <player>", CommandUsage.CLIENT_ONLY)]
+	[CommandHelper(1, "[target]", CommandUsage.CLIENT_ONLY)]
 	public void Command_Toggle(CCSPlayerController? player, CommandInfo command)
 	{
+		if (player == null)
+			return;
 
+		if (!_warden.IsWarden(player))
+			//	You're not that warden, blud
+			return;
+
+		//	Since we have min_args, don't need to check for validity here.
+		//	just only get targets that are T's.
+		var targets = command.GetArgTargetResult(1);
+		var eligible = targets
+			.Where(player => player.Team == CsTeam.Terrorist)
+			.ToList();
+
+		if (eligible.Count == 0)
+		{
+			_generic.PlayerNotFound(command.GetArg(1))
+				.ToPlayerChat(player)
+				.ToPlayerConsole(player);
+			return;
+		}
+		else if (eligible.Count != 1)
+		{
+			_generic.PlayerFoundMultiple(command.GetArg(1))
+				.ToPlayerChat(player)
+				.ToPlayerConsole(player);
+			return;
+		}
+
+		//	One target, mark as ST.
+		var special = eligible.First();
+
+		if (_specialTreatment.IsSpecialTreatment(special))
+		{
+			//	Revoke
+			_specialTreatment.Revoke(special);
+		}
+		else
+		{
+			//	Player does not have ST, grant
+			_specialTreatment.Grant(special);
+		}
 	}
 }

--- a/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
+++ b/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
@@ -1,0 +1,90 @@
+﻿using System.Drawing;
+
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+
+using Jailbreak.Formatting.Extensions;
+using Jailbreak.Formatting.Views;
+using Jailbreak.Public.Behaviors;
+using Jailbreak.Public.Generic;
+using Jailbreak.Public.Mod.Rebel;
+using Jailbreak.Public.Mod.Warden;
+
+namespace Jailbreak.Warden.SpecialTreatment;
+
+public class SpecialTreatmentBehavior : IPluginBehavior, ISpecialTreatmentService
+{
+    private IPlayerState<SpecialTreatmentState> _sts;
+    private IRebelService _rebel;
+    private ISpecialTreatmentNotifications _notifications;
+
+    public SpecialTreatmentBehavior(IPlayerStateFactory factory, IRebelService rebel, ISpecialTreatmentNotifications notifications)
+    {
+        _sts = factory.Round<SpecialTreatmentState>();
+
+        _rebel = rebel;
+        _notifications = notifications;
+    }
+
+    private class SpecialTreatmentState
+    {
+        public bool HasSpecialTreatment { get; set; } = false;
+    }
+
+    public bool IsSpecialTreatment(CCSPlayerController player)
+    {
+        return _sts.Get(player)
+            .HasSpecialTreatment;
+    }
+
+    public void Grant(CCSPlayerController player)
+    {
+        //  Player is already granted ST
+        if (IsSpecialTreatment(player))
+            return;
+
+        _sts.Get(player).HasSpecialTreatment = true;
+
+        _rebel.UnmarkRebel(player);
+        this.SetPlayerColor(player, /* hasSt */ true);
+
+        _notifications.GRANTED
+            .ToPlayerChat(player)
+            .ToPlayerCenter(player);
+
+        _notifications.GRANTED_TO(player)
+            .ToAllChat();
+    }
+
+    public void Revoke(CCSPlayerController player)
+    {
+        //  Player is already revoked
+        if (!IsSpecialTreatment(player))
+            return;
+
+        _sts.Get(player).HasSpecialTreatment = false;
+
+        this.SetPlayerColor(player, /* hasSt */ false);
+
+        _notifications.REVOKED
+            .ToPlayerChat(player)
+            .ToPlayerCenter(player);
+
+        _notifications.REVOKED_FROM(player)
+            .ToAllChat();
+    }
+
+    private void SetPlayerColor(CCSPlayerController player, bool hasSt)
+    {
+        if (!player.IsValid || player.Pawn.Value == null)
+            return;
+
+        var color = hasSt
+            ? Color.FromArgb(254, 150, 255, 150)
+            : Color.FromArgb(254, 255, 255, 255);
+
+        player.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
+        player.Pawn.Value.Render = color;
+        Utilities.SetStateChanged(player.Pawn.Value, "CBaseModelEntity", "m_clrRender");
+    }
+}

--- a/mod/Jailbreak.Warden/WardenServiceExtension.cs
+++ b/mod/Jailbreak.Warden/WardenServiceExtension.cs
@@ -5,6 +5,8 @@ using Jailbreak.Warden.Global;
 using Jailbreak.Warden.Markers;
 using Jailbreak.Warden.Paint;
 using Jailbreak.Warden.Selection;
+using Jailbreak.Warden.SpecialTreatment;
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jailbreak.Warden;
@@ -15,6 +17,7 @@ public static class WardenServiceExtension
     {
         serviceCollection.AddPluginBehavior<IWardenService, WardenBehavior>();
         serviceCollection.AddPluginBehavior<IWardenSelectionService, WardenSelectionBehavior>();
+        serviceCollection.AddPluginBehavior<ISpecialTreatmentService, SpecialTreatmentBehavior>();
 
         serviceCollection.AddPluginBehavior<WardenCommandsBehavior>();
         serviceCollection.AddPluginBehavior<WardenMarkerBehavior>();

--- a/mod/Jailbreak.Warden/WardenServiceExtension.cs
+++ b/mod/Jailbreak.Warden/WardenServiceExtension.cs
@@ -19,7 +19,9 @@ public static class WardenServiceExtension
         serviceCollection.AddPluginBehavior<IWardenSelectionService, WardenSelectionBehavior>();
         serviceCollection.AddPluginBehavior<ISpecialTreatmentService, SpecialTreatmentBehavior>();
 
+        serviceCollection.AddPluginBehavior<SpecialTreatmentCommandsBehavior>();
         serviceCollection.AddPluginBehavior<WardenCommandsBehavior>();
+
         serviceCollection.AddPluginBehavior<WardenMarkerBehavior>();
         serviceCollection.AddPluginBehavior<WardenPaintBehavior>();
     }

--- a/public/Jailbreak.Formatting/Logistics/LanguageConfig.cs
+++ b/public/Jailbreak.Formatting/Logistics/LanguageConfig.cs
@@ -34,8 +34,12 @@ public class LanguageConfig<TDialect>
 	public void WithLogging<TLogging>()
 		where TLogging : class, ILanguage<TDialect>, ILogMessages
 		=> _collection.AddSingleton<ILogMessages, TLogging>();
-	
+
 	public void WithLastRequest<TLastRequest>()
 		where TLastRequest : class, ILanguage<TDialect>, ILastRequestMessages
 		=> _collection.AddSingleton<ILastRequestMessages, TLastRequest>();
+
+	public void WithSpecialTreatment<TSpecialTreatment>()
+		where TSpecialTreatment : class, ILanguage<TDialect>, ISpecialTreatmentNotifications
+		=> _collection.AddSingleton<ISpecialTreatmentNotifications, TSpecialTreatment>();
 }

--- a/public/Jailbreak.Formatting/Views/ISpecialTreatmentNotifications.cs
+++ b/public/Jailbreak.Formatting/Views/ISpecialTreatmentNotifications.cs
@@ -1,0 +1,17 @@
+﻿using CounterStrikeSharp.API.Core;
+
+using Jailbreak.Formatting.Base;
+
+namespace Jailbreak.Formatting.Views;
+
+public interface ISpecialTreatmentNotifications
+{
+	public IView GRANTED { get; }
+
+	public IView REVOKED { get; }
+
+	public IView GRANTED_TO(CCSPlayerController player);
+
+	public IView REVOKED_FROM(CCSPlayerController player);
+
+}

--- a/public/Jailbreak.Public/Mod/Warden/ISpecialTreatmentService.cs
+++ b/public/Jailbreak.Public/Mod/Warden/ISpecialTreatmentService.cs
@@ -1,0 +1,21 @@
+﻿using CounterStrikeSharp.API.Core;
+
+namespace Jailbreak.Public.Mod.Warden;
+
+public interface ISpecialTreatmentService
+{
+	public bool IsSpecialTreatment(CCSPlayerController player);
+
+	/// <summary>
+	/// Give this player ST for the rest of the round
+	/// </summary>
+	/// <param name="player"></param>
+	public void Grant(CCSPlayerController player);
+
+	/// <summary>
+	/// Revoke the player's special treatment for the current round
+	/// Does nothing if not ST.
+	/// </summary>
+	/// <param name="player"></param>
+	public void Revoke(CCSPlayerController player);
+}

--- a/src/Jailbreak/JailbreakServiceCollection.cs
+++ b/src/Jailbreak/JailbreakServiceCollection.cs
@@ -50,6 +50,7 @@ public class JailbreakServiceCollection : IPluginServiceCollection<Jailbreak>
 			config.WithRebel<RebelNotifications>();
 			config.WithLogging<LogMessages>();
 			config.WithLastRequest<LastRequestMessages>();
+			config.WithSpecialTreatment<SpecialTreatmentNotifications>();
 		});
 	}
 }


### PR DESCRIPTION
Adds special treatment handling for wardens.

- New command: `!st <target>` - If there is a target and a T, ST will be toggled on that player.
- New service: ST service - Tracks state of STs and colors all active STs green. Does not revoke ST upon rebel (yet!)