### PR TITLE
css_fire with support for peace mute

### DIFF
--- a/lang/Jailbreak.English/Warden/WardenNotifications.cs
+++ b/lang/Jailbreak.English/Warden/WardenNotifications.cs
@@ -47,7 +47,10 @@ public class WardenNotifications : IWardenNotifications, ILanguage<Formatting.La
 	public IView NOT_WARDEN =>
 		new SimpleView { PREFIX, "You are not the warden!" };
 
-	public IView PASS_WARDEN(CCSPlayerController player)
+    public IView FIRE_COMMAND_FAILED =>
+    new SimpleView { PREFIX, "The fire command has failed to work for some unknown reason..." };
+
+    public IView PASS_WARDEN(CCSPlayerController player)
 	{
 		return new SimpleView { PREFIX, player, "has resigned from being warden!" };
 	}
@@ -64,4 +67,9 @@ public class WardenNotifications : IWardenNotifications, ILanguage<Formatting.La
 		else
 			return new SimpleView { PREFIX, "There is currently no warden!" };
 	}
+    public IView FIRE_COMMAND_SUCCESS(CCSPlayerController player)
+    {
+        return new SimpleView { PREFIX, player, "has been fired and is no longer the warden." };
+    }
+
 }

--- a/mod/Jailbreak.Mute/MuteConfig.cs
+++ b/mod/Jailbreak.Mute/MuteConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace Jailbreak.Mute;
+
+public class MuteConfig
+{
+    public bool PeaceShouldConsiderMutedPlayers { get; } = false;
+}

--- a/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Events;
 using CounterStrikeSharp.API.Modules.Memory;
@@ -9,6 +10,7 @@ using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.Mute;
 using Jailbreak.Public.Mod.Warden;
 
 namespace Jailbreak.Warden.Commands;
@@ -19,17 +21,20 @@ public class WardenCommandsBehavior : IPluginBehavior
     private readonly IWardenSelectionService _queue;
     private readonly IWardenService _warden;
     private readonly IGenericCommandNotifications _generics;
+    private readonly IMuteService _mute;
+
     private readonly WardenConfig _config;
     private readonly Dictionary<CCSPlayerController, DateTime> _lastWardenCommand = new();
 
     public WardenCommandsBehavior(IWardenSelectionService queue, IWardenService warden,
-        IWardenNotifications notifications, IGenericCommandNotifications generics, WardenConfig config)
+        IWardenNotifications notifications, IGenericCommandNotifications generics, IMuteService mute, WardenConfig config)
     {
         _config = config;
         _queue = queue;
         _warden = warden;
         _generics = generics;
         _notifications = notifications;
+        _mute = mute;
     }
 
     [GameEventHandler]
@@ -114,4 +119,24 @@ public class WardenCommandsBehavior : IPluginBehavior
 
         _notifications.CURRENT_WARDEN(_warden.Warden).ToPlayerChat(player);
     }
+
+    [ConsoleCommand("css_fire", "Fires the currently active warden, if any.")]
+    [CommandHelper(0, "", CommandUsage.CLIENT_AND_SERVER)]
+    public void Command_FireWarden(CCSPlayerController? player, CommandInfo command)
+    {
+        CCSPlayerController? warden = _warden.Warden;
+        if (player == null || warden == null) return;
+        if (!AdminManager.PlayerHasPermissions(player, "@css/eg")) { return; }
+        bool success = _warden.TryRemoveWarden();
+
+        if (!success)
+            _notifications.FIRE_COMMAND_FAILED.ToPlayerChat(player);
+        else
+        {
+            _notifications.FIRE_COMMAND_SUCCESS(warden).ToAllChat();
+            _mute.RemovePeaceMute();
+        }
+
+    }
+
 }

--- a/public/Jailbreak.Formatting/Views/IWardenNotifications.cs
+++ b/public/Jailbreak.Formatting/Views/IWardenNotifications.cs
@@ -14,6 +14,7 @@ public interface IWardenNotifications
     public IView JOIN_RAFFLE { get; }
     public IView LEAVE_RAFFLE { get; }
     public IView NOT_WARDEN { get; }
+    public IView FIRE_COMMAND_FAILED { get; }
 
     /// <summary>
     ///     Create a view for when the specified player passes warden
@@ -36,4 +37,7 @@ public interface IWardenNotifications
     /// <param name="player"></param>
     /// <returns></returns>
     public IView CURRENT_WARDEN(CCSPlayerController? player);
+
+    public IView FIRE_COMMAND_SUCCESS(CCSPlayerController player);
+
 }

--- a/public/Jailbreak.Public/Mod/Mute/IMuteService.cs
+++ b/public/Jailbreak.Public/Mod/Mute/IMuteService.cs
@@ -5,8 +5,7 @@ namespace Jailbreak.Public.Mod.Mute;
 public interface IMuteService
 {
     void PeaceMute(MuteReason reason);
-
+    void RemovePeaceMute();
     bool IsPeaceEnabled();
-
     DateTime GetLastPeace();
 }


### PR DESCRIPTION
This PR adds the css_fire command to fire the current warden (if any).

List of changes here:
- Added css_fire command 
- Added ability to remove an active peace mute in the API
- Notifications support for command 
- Improved peace mute logic slightly by making sure it only mutes players who were PREVIOUSLY unmuted, this means peace mute has no effect on already-muted players! 
- Changed peace mute logic slightly by adding a list of muted players, this is required to have the functionality of being able to remove a peace mute before the timer has run out.
- Added edge case check for mute system

Please note I could not branch from dev as I needed the mute system code so I could implement it in the css_fire logic!

