### PR TITLE
css_fire implementation

### DIFF
--- a/Jailbreak.sln
+++ b/Jailbreak.sln
@@ -1,34 +1,37 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{177DA48D-8306-4102-918D-992569878581}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak", "src\Jailbreak\Jailbreak.csproj", "{9135CCC9-66C5-4A9C-AE3C-91475B5F0437}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak", "src\Jailbreak\Jailbreak.csproj", "{9135CCC9-66C5-4A9C-AE3C-91475B5F0437}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "public", "public", "{59311734-3648-43C2-B43C-385718B0D103}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Public", "public\Jailbreak.Public\Jailbreak.Public.csproj", "{51AF228F-27F2-4225-A387-FDEAD123FAC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Public", "public\Jailbreak.Public\Jailbreak.Public.csproj", "{51AF228F-27F2-4225-A387-FDEAD123FAC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "mod", "mod", "{36BA84C0-291C-4930-A7C6-97CDF8F7F0D7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Warden", "mod\Jailbreak.Warden\Jailbreak.Warden.csproj", "{E73417E7-D397-415B-B96F-BF43DAC511B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Warden", "mod\Jailbreak.Warden\Jailbreak.Warden.csproj", "{E73417E7-D397-415B-B96F-BF43DAC511B8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Generic", "src\Jailbreak.Generic\Jailbreak.Generic.csproj", "{1D9CC1AC-4ABC-41A3-8CC7-6FB17E864C3F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Generic", "src\Jailbreak.Generic\Jailbreak.Generic.csproj", "{1D9CC1AC-4ABC-41A3-8CC7-6FB17E864C3F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Formatting", "public\Jailbreak.Formatting\Jailbreak.Formatting.csproj", "{446E0B6F-E4FE-45E6-BD9B-BD943698327A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Formatting", "public\Jailbreak.Formatting\Jailbreak.Formatting.csproj", "{446E0B6F-E4FE-45E6-BD9B-BD943698327A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lang", "lang", "{CDCDE44E-01D2-4B76-99DA-A57E1E956038}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.English", "lang\Jailbreak.English\Jailbreak.English.csproj", "{FC2D6F50-BCFF-41E6-A965-6C73CC01C3BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.English", "lang\Jailbreak.English\Jailbreak.English.csproj", "{FC2D6F50-BCFF-41E6-A965-6C73CC01C3BF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Rebel", "mod\Jailbreak.Rebel\Jailbreak.Rebel.csproj", "{CB2391A1-6CDD-496F-B8D6-674FD6268038}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Rebel", "mod\Jailbreak.Rebel\Jailbreak.Rebel.csproj", "{CB2391A1-6CDD-496F-B8D6-674FD6268038}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Logs", "mod\Jailbreak.Logs\Jailbreak.Logs.csproj", "{CE6EC648-E7F9-4CE7-B28F-8C7995830F35}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Logs", "mod\Jailbreak.Logs\Jailbreak.Logs.csproj", "{CE6EC648-E7F9-4CE7-B28F-8C7995830F35}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Debug", "mod\Jailbreak.Debug\Jailbreak.Debug.csproj", "{4F10E2B5-E8BB-4253-9BE6-9187575ADB13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Debug", "mod\Jailbreak.Debug\Jailbreak.Debug.csproj", "{4F10E2B5-E8BB-4253-9BE6-9187575ADB13}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.LastRequest", "mod\Jailbreak.LastRequest\Jailbreak.LastRequest.csproj", "{D8952626-7B8D-4ABB-A3AE-FC81C688787B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.LastRequest", "mod\Jailbreak.LastRequest\Jailbreak.LastRequest.csproj", "{D8952626-7B8D-4ABB-A3AE-FC81C688787B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jailbreak.Mute", "mod\Jailbreak.Mute\Jailbreak.Mute.csproj", "{C9F050A5-5B08-4F48-98F5-B5792A217DB0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jailbreak.Mute", "mod\Jailbreak.Mute\Jailbreak.Mute.csproj", "{C9F050A5-5B08-4F48-98F5-B5792A217DB0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +83,9 @@ Global
 		{C9F050A5-5B08-4F48-98F5-B5792A217DB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9F050A5-5B08-4F48-98F5-B5792A217DB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9F050A5-5B08-4F48-98F5-B5792A217DB0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9135CCC9-66C5-4A9C-AE3C-91475B5F0437} = {177DA48D-8306-4102-918D-992569878581}

--- a/lang/Jailbreak.English/Warden/WardenNotifications.cs
+++ b/lang/Jailbreak.English/Warden/WardenNotifications.cs
@@ -47,7 +47,10 @@ public class WardenNotifications : IWardenNotifications, ILanguage<Formatting.La
 	public IView NOT_WARDEN =>
 		new SimpleView { PREFIX, "You are not the warden!" };
 
-	public IView PASS_WARDEN(CCSPlayerController player)
+    public IView FIRE_COMMAND_FAILED =>
+    new SimpleView { PREFIX, "The fire command has failed to work for some unknown reason..." };
+
+    public IView PASS_WARDEN(CCSPlayerController player)
 	{
 		return new SimpleView { PREFIX, player, "has resigned from being warden!" };
 	}
@@ -64,4 +67,9 @@ public class WardenNotifications : IWardenNotifications, ILanguage<Formatting.La
 		else
 			return new SimpleView { PREFIX, "There is currently no warden!" };
 	}
+    public IView FIRE_COMMAND_SUCCESS(CCSPlayerController player)
+    {
+        return new SimpleView { PREFIX, player, "has been fired and is no longer the warden." };
+    }
+
 }

--- a/mod/Jailbreak.Mute/MuteConfig.cs
+++ b/mod/Jailbreak.Mute/MuteConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace Jailbreak.Mute;
+
+public class MuteConfig
+{
+    public bool PeaceShouldConsiderMutedPlayers { get; } = false;
+}

--- a/mod/Jailbreak.Mute/MuteServiceExtension.cs
+++ b/mod/Jailbreak.Mute/MuteServiceExtension.cs
@@ -8,6 +8,8 @@ public static class MuteServiceExtension
 {
     public static void AddJailbreakMute(this IServiceCollection services)
     {
+        services.AddConfig<MuteConfig>("muteconfig");
+
         services.AddPluginBehavior<IMuteService, MuteSystem>();
     }
 }

--- a/mod/Jailbreak.Mute/MuteSystem.cs
+++ b/mod/Jailbreak.Mute/MuteSystem.cs
@@ -14,7 +14,7 @@ using Timer = CounterStrikeSharp.API.Modules.Timers.Timer;
 
 namespace Jailbreak.Mute;
 
-public class MuteSystem(IServiceProvider provider) : IPluginBehavior, IMuteService
+public class MuteSystem(IServiceProvider provider, MuteConfig muteConfig) : IPluginBehavior, IMuteService
 {
     private BasePlugin parent;
     private DateTime lastPeace = DateTime.MinValue;
@@ -47,8 +47,8 @@ public class MuteSystem(IServiceProvider provider) : IPluginBehavior, IMuteServi
     public void PeaceMute(MuteReason reason)
     {
         var duration = GetPeaceDuration(reason);
-        var ctDuration = Math.Min(10, duration); //                                      This check ensures we only mute players who aren't already muted.
-        foreach (var player in Utilities.GetPlayers().Where(player => player.IsReal() && (player.VoiceFlags & VoiceFlags.Muted) == 0))
+        var ctDuration = Math.Min(10, duration); //                                      This check ensures we only mute players who aren't already muted, if the config allows it.
+        foreach (var player in Utilities.GetPlayers().Where(player => player.IsReal() && (muteConfig.PeaceShouldConsiderMutedPlayers) ? (player.VoiceFlags & VoiceFlags.Muted) == 0 : true))
             if (!warden.IsWarden(player))
             {
                 mute(player); _mutedPlayers.Add(player);

--- a/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
@@ -3,6 +3,7 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Entities;
 using CounterStrikeSharp.API.Modules.Events;
 using CounterStrikeSharp.API.Modules.Memory;
 using CounterStrikeSharp.API.Modules.Utils;
@@ -125,8 +126,10 @@ public class WardenCommandsBehavior : IPluginBehavior
     public void Command_FireWarden(CCSPlayerController? player, CommandInfo command)
     {
         CCSPlayerController? warden = _warden.Warden;
-        if (player == null || warden == null) return;
+
+        if (player == null || warden == null) { return; }
         if (!AdminManager.PlayerHasPermissions(player, "@css/eg")) { return; }
+
         bool success = _warden.TryRemoveWarden();
 
         if (!success)
@@ -135,6 +138,15 @@ public class WardenCommandsBehavior : IPluginBehavior
         {
             _notifications.FIRE_COMMAND_SUCCESS(warden).ToAllChat();
             _mute.RemovePeaceMute();
+
+            // TEMP SOLUTION. Eventually we want to use EmitSound in the world instead, waiting for CS#... 
+            foreach (var p in Utilities.GetPlayers())
+            {
+                if (!p.IsReal()) continue;
+                p.ExecuteClientCommand(
+                    $"play sounds/{_config.WardenKilledSoundName}");
+            }
+
         }
 
     }

--- a/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Events;
 using CounterStrikeSharp.API.Modules.Memory;
@@ -9,6 +10,7 @@ using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.Mute;
 using Jailbreak.Public.Mod.Warden;
 
 namespace Jailbreak.Warden.Commands;
@@ -19,17 +21,20 @@ public class WardenCommandsBehavior : IPluginBehavior
     private readonly IWardenSelectionService _queue;
     private readonly IWardenService _warden;
     private readonly IGenericCommandNotifications _generics;
+    private readonly IMuteService _mute;
+
     private readonly WardenConfig _config;
     private readonly Dictionary<CCSPlayerController, DateTime> _lastWardenCommand = new();
 
     public WardenCommandsBehavior(IWardenSelectionService queue, IWardenService warden,
-        IWardenNotifications notifications, IGenericCommandNotifications generics, WardenConfig config)
+        IWardenNotifications notifications, IGenericCommandNotifications generics, IMuteService mute, WardenConfig config)
     {
         _config = config;
         _queue = queue;
         _warden = warden;
         _generics = generics;
         _notifications = notifications;
+        _mute = mute;
     }
 
     [GameEventHandler]
@@ -114,4 +119,24 @@ public class WardenCommandsBehavior : IPluginBehavior
 
         _notifications.CURRENT_WARDEN(_warden.Warden).ToPlayerChat(player);
     }
+
+    [ConsoleCommand("css_fire", "Fires the currently active warden, if any.")]
+    [CommandHelper(0, "", CommandUsage.CLIENT_AND_SERVER)]
+    public void Command_FireWarden(CCSPlayerController? player, CommandInfo command)
+    {
+        CCSPlayerController? warden = _warden.Warden;
+        if (player == null || warden == null) return;
+        if (!AdminManager.PlayerHasPermissions(player, "@css/eg")) { return; }
+        bool success = _warden.TryRemoveWarden();
+
+        if (!success)
+            _notifications.FIRE_COMMAND_FAILED.ToPlayerChat(player);
+        else
+        {
+            _notifications.FIRE_COMMAND_SUCCESS(warden).ToAllChat();
+            _mute.RemovePeaceMute();
+        }
+
+    }
+
 }

--- a/public/Jailbreak.Formatting/Views/IWardenNotifications.cs
+++ b/public/Jailbreak.Formatting/Views/IWardenNotifications.cs
@@ -14,6 +14,7 @@ public interface IWardenNotifications
     public IView JOIN_RAFFLE { get; }
     public IView LEAVE_RAFFLE { get; }
     public IView NOT_WARDEN { get; }
+    public IView FIRE_COMMAND_FAILED { get; }
 
     /// <summary>
     ///     Create a view for when the specified player passes warden
@@ -36,4 +37,7 @@ public interface IWardenNotifications
     /// <param name="player"></param>
     /// <returns></returns>
     public IView CURRENT_WARDEN(CCSPlayerController? player);
+
+    public IView FIRE_COMMAND_SUCCESS(CCSPlayerController player);
+
 }

--- a/public/Jailbreak.Public/Jailbreak.Public.csproj
+++ b/public/Jailbreak.Public/Jailbreak.Public.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.202"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.0"/>
+        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.213" />
+        <PackageReference Include="System.Text.Json" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Plugin\"/>
+        <Folder Include="Plugin\" />
     </ItemGroup>
 
 </Project>

--- a/public/Jailbreak.Public/Mod/Mute/IMuteService.cs
+++ b/public/Jailbreak.Public/Mod/Mute/IMuteService.cs
@@ -5,8 +5,7 @@ namespace Jailbreak.Public.Mod.Mute;
 public interface IMuteService
 {
     void PeaceMute(MuteReason reason);
-
+    void RemovePeaceMute();
     bool IsPeaceEnabled();
-
     DateTime GetLastPeace();
 }


### PR DESCRIPTION
Overview of changes surrounding css_fire:

- IMPORTANT: This is on CS# version 213
- Peace mute can account for muted players with optional config, the default value is false
- Improved peace mute logic slightly by storing a list of players to mute before the command is run
- Added ability to remove a peace mute in the API, which utilizes the previous bullet point
- Plays a sound when the warden is fired 
- Notifications support

