### PR TITLE
Jihad C4

### DIFF
--- a/lang/Jailbreak.English/Rebel/JihadC4Notifications.cs
+++ b/lang/Jailbreak.English/Rebel/JihadC4Notifications.cs
@@ -1,0 +1,26 @@
+﻿using CounterStrikeSharp.API.Core;
+using Jailbreak.Formatting.Base;
+using Jailbreak.Formatting.Logistics;
+using Jailbreak.Formatting.Views;
+using Jailbreak.Public.Mod.Rebel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jailbreak.English.Rebel;
+
+public class JihadC4Notifications : IJihadC4Notifications, ILanguage<Formatting.Languages.English>
+{
+    public IView JIHAD_C4_DROPPED => new SimpleView { RebelNotifications.PREFIX, "You dropped your Jihad C4!" };
+
+    public IView JIHAD_C4_PICKUP => new SimpleView { RebelNotifications.PREFIX, "You picked up a Jihad C4!" };
+
+    public IView JIHAD_C4_RECEIVED => new SimpleView { RebelNotifications.PREFIX, "You received a Jihad C4!" };
+
+    public IView PlayerDetonateC4(CCSPlayerController player)
+    {
+        return new SimpleView { RebelNotifications.PREFIX, $"{player.PlayerName} has detonated a Jihad C4!" };
+    }
+}

--- a/mod/Jailbreak.Rebel/Jailbreak.Rebel.csproj
+++ b/mod/Jailbreak.Rebel/Jailbreak.Rebel.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\public\Jailbreak.Formatting\Jailbreak.Formatting.csproj"/>
-        <ProjectReference Include="..\..\public\Jailbreak.Public\Jailbreak.Public.csproj"/>
+        <ProjectReference Include="..\..\public\Jailbreak.Formatting\Jailbreak.Formatting.csproj" />
+        <ProjectReference Include="..\..\public\Jailbreak.Public\Jailbreak.Public.csproj" />
     </ItemGroup>
 
 </Project>

--- a/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
+++ b/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
@@ -21,10 +21,11 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
     private IJihadC4Notifications _jihadNotifications;
     private BasePlugin _basePlugin;
 
-    // The key represents the active jihad c4, the pair represents the bomb metadata
+    // Key presents any active Jihad C4 in the world. Values represent metadata about that Jihad C4.
     private Dictionary<CC4, JihadBombMetadata> _currentActiveJihadC4s = new();
 
     // Windows AND Linux... :)
+    // Todo actually test this in the various funcs (the sig does work though)
     private readonly MemoryFunctionVoid<nint, string, int, float, float> CBaseEntity_EmitSoundParams = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ? new("\\x48\\xB8\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x55\\x48\\x89\\xE5\\x41\\x55\\x41\\x54\\x49\\x89\\xFC\\x53\\x48\\x89\\xF3") : new("\\x48\\x8B\\xC4\\x48\\x89\\x58\\x10\\x48\\x89\\x70\\x18\\x55\\x57\\x41\\x56\\x48\\x8D\\xA8\\x08\\xFF\\xFF\\xFF");
 
     // todo add notification support here
@@ -36,16 +37,16 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
     public void Start(BasePlugin basePlugin)
     {
         _basePlugin = basePlugin;
+        // Register an OnTick listener to listen for +use
         _basePlugin.RegisterListener<Listeners.OnTick>(PlayerUseC4ListenerCallback);
     }
 
-   
-
     // TODO HANDLE WHEN PLAYER LEAVES AND STUFF LIKE THAT
 
-
     /// <summary>
-    /// Checks when a player attempts to detonate the C4 (by doing +use). This function then handles certain things and calls another function to actually detonte it.
+    /// This function listens to when a player with an active Jihad C4 detonates their bomb by doing +use.
+    /// It will call another function to actually produce the Jihad C4 styled explosion, and handles removing the player 
+    /// from the list of active C4's, to name one thing.
     /// </summary>
     private void PlayerUseC4ListenerCallback()
     {
@@ -57,34 +58,28 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
 
             // is the use button currently active? 
             if ((player.Buttons & PlayerButtons.Use) == 0) { continue; }
-            Console.WriteLine("2");
 
             CPlayer_WeaponServices? weaponServices = TryGetWeaponServices(player);
             if (weaponServices == null || weaponServices.ActiveWeapon == null || weaponServices.ActiveWeapon.Value == null || !weaponServices.ActiveWeapon.Value.IsValid) { continue; }
-            Console.WriteLine("2.1??");
-            // Check if the currently held and "used" item is our C4
+            
+            // Check if the currently held and "+used" item is our C4
             if (!weaponServices.ActiveWeapon!.Value!.DesignerName.Equals("weapon_c4")) { continue; }
-            Console.WriteLine("2.2");
 
             CC4 bombEntity = new CC4(weaponServices.ActiveWeapon!.Value!.Handle);
-            Console.WriteLine("is bomb valid tho: " + bombEntity.IsValid);
-            // _currentActiveJihadC4s.Remove(bombEntity); DEBUG1
-            Console.WriteLine("3");
+            _currentActiveJihadC4s.Remove(bombEntity);
 
-            //player.ExecuteClientCommandFromServer("kill"); UNCOMMENT LATER
-            //TryDetonateJihadC4(player, metadata.Delay);
+            //player.ExecuteClientCommandFromServer("kill"); UNCOMMENT LATER ONCE YOU'RE DONE WITH PLUGIN
+            TryDetonateJihadC4(player, metadata.Delay);
             Console.WriteLine("4");
 
-            //_jihadNotifications.PlayerDetonateC4(player).ToAllChat();
+            _jihadNotifications.PlayerDetonateC4(player).ToAllChat();
 
-            // todo next frame print chat
-
-            /**Server.NextFrame(bombEntity.Remove);
-            Console.WriteLine("5");**/ // UNCOMMENT LATER AND LOOK INTO THIS, HOW TO REMOVE C4 AFTER KILL CMD
+            Server.NextFrame(bombEntity.Remove); // todo check if this actually works
 
         }
     }
 
+    // Todo please remove later!!
     [ConsoleCommand("css_d", "debug cmd")]
     public void Command_Debug(CCSPlayerController? executor, CommandInfo info)
     {
@@ -94,6 +89,13 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
 
     }
 
+    /// <summary>
+    /// This function importantly allows players who have a Jihad C4 to pass it on to other Terrorists. Additionally it deals with
+    /// the edge case where a player dies with a Jihad C4, as this function is still called when that happens.
+    /// </summary>
+    /// <param name="event"></param>
+    /// <param name="info"></param>
+    /// <returns></returns>
     [GameEventHandler]
     public HookResult OnPlayerDropC4(EventBombDropped @event, GameEventInfo info)
     {
@@ -107,13 +109,20 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
 
         // If a jihad bomb is dropped then the player entry in the dictionary needs to be nulled. We will set it again when another player picks it up.
         _currentActiveJihadC4s[bombEntity].Player = null;
-        // This requires a nextframe because apparently some Valve functions don't like printing inside of them ??!?!
+        // This requires a nextframe because apparently some Valve functions don't like printing inside of them.
         Server.NextFrame(() => { _jihadNotifications.JIHAD_C4_DROPPED.ToPlayerChat(player); });
 
         return HookResult.Continue;
 
     }
 
+    /// <summary>
+    /// This function listens to when a player picks up any weapon_c4 item. If it is a Jihad C4 (which can easily be checked) then
+    /// we assign the Jihad C4's "owner" to that player. 
+    /// </summary>
+    /// <param name="event"></param>
+    /// <param name="info"></param>
+    /// <returns></returns>
     [GameEventHandler]
     public HookResult OnPlayerPickupC4(EventBombPickup @event, GameEventInfo info)
     {
@@ -123,7 +132,7 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
         CPlayer_WeaponServices? weaponServices = TryGetWeaponServices(player);
         if (weaponServices == null) { Console.WriteLine("Weaponservice was null in OnPlayerPickupC4"); return HookResult.Continue; }
 
-        CC4 bombEntity = new CC4(weaponServices.MyWeapons.Last()!.Value!.Handle); // The last item in the weapons list is the last item to be picked up, apparently...
+        CC4 bombEntity = new CC4(weaponServices.MyWeapons.Last()!.Value!.Handle); // The last item in the weapons list is the last item the player picked up, apparently
         if (!_currentActiveJihadC4s.ContainsKey(bombEntity)) { return HookResult.Continue; }
 
         _currentActiveJihadC4s[bombEntity].Player = player;
@@ -133,6 +142,12 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
 
     }
 
+    /// <summary>
+    /// A useful function to reset the Jihad C4 state. A better solution might be to clear the list on round START instead.
+    /// </summary>
+    /// <param name="event"></param>
+    /// <param name="info"></param>
+    /// <returns></returns>
     [GameEventHandler]
     public HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
     {
@@ -140,6 +155,38 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
         return HookResult.Continue;
     }
 
+    /// <summary>
+    /// The purpose of this event handler is to safely handle when a player with an active Jihad C4 leaves the server.
+    /// It ensures that the Jihad C4 that is dropped when they are disconnected is still useable.
+    /// </summary>
+    /// <param name="event"></param>
+    /// <param name="info"></param>
+    /// <returns></returns>
+    [GameEventHandler]
+    public HookResult OnPlayerLeave(EventPlayerDisconnect @event, GameEventInfo info)
+    {
+        if (_currentActiveJihadC4s.Count == 0) { return HookResult.Continue; }
+
+        CCSPlayerController? player = @event.Userid;
+        if (player == null || !player.IsValid) { return HookResult.Continue; }
+
+        foreach (JihadBombMetadata metadata in _currentActiveJihadC4s.Values)
+        {
+            if (metadata.Player == player)
+            {
+                metadata.Player = null;
+            }
+        }
+
+        return HookResult.Continue;
+
+    }
+
+    /// <summary>
+    /// Self-explanatory function. This function registers the given C4 and the player who received the bomb.
+    /// If this function fails then nothing will happen.
+    /// </summary>
+    /// <param name="player"></param>
     public void TryGiveC4ToPlayer(CCSPlayerController player)
     {
         CC4 bombEntity = new CC4(player.GiveNamedItem("weapon_c4"));
@@ -148,27 +195,35 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
     }
 
     // Not using _notifications.PlayerDetonateC4() here, as I invoked that in the +use callback already
+    /// <summary>
+    /// This function creates a Jihad C4 styled explosion centred at the player's AbsOrigin. This function doesn't check if 
+    /// the player even has a C4, it is simply used to create the explosion!
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="delay"></param>
     public void TryDetonateJihadC4(CCSPlayerController player, float delay)
     {
         /* PARTICLE EXPLOSION */
-        /**CParticleSystem particleSystemEntity = Utilities.CreateEntityByName<CParticleSystem>("info_particle_system")!;
+        CParticleSystem particleSystemEntity = Utilities.CreateEntityByName<CParticleSystem>("info_particle_system")!;
         particleSystemEntity.EffectName = "particles/explosions_fx/explosion_c4_500.vpcf";
         particleSystemEntity.StartActive = true;
 
         particleSystemEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin!, new QAngle(), new Vector());
-        particleSystemEntity.DispatchSpawn();**/
+        particleSystemEntity.DispatchSpawn();
 
         /* PHYS EXPLPOSION, FOR PUSHING PLAYERS */
-        /**CPhysExplosion envPhysExplosionEntity = Utilities.CreateEntityByName<CPhysExplosion>("env_physexplosion")!;
+        /* Values can always be tweaked, the important ones are Magnitude and Pushscale */
+        /* Currently this physics explosion will affect players through walls, can easily change this though */
+        CPhysExplosion envPhysExplosionEntity = Utilities.CreateEntityByName<CPhysExplosion>("env_physexplosion")!;
 
-        envPhysExplosionEntity.Spawnflags = 1 << 1;
+        envPhysExplosionEntity.Spawnflags = 1 << 1; // Push players flag set to true!
         envPhysExplosionEntity.ExplodeOnSpawn = true;
         envPhysExplosionEntity.Magnitude = 50f;
         envPhysExplosionEntity.PushScale = 3.5f;
         envPhysExplosionEntity.Radius = 340f; // As per old code.
 
         envPhysExplosionEntity.Teleport(player.PlayerPawn.Value!.AbsOrigin!, new QAngle(), new Vector());
-        envPhysExplosionEntity.DispatchSpawn();**/
+        envPhysExplosionEntity.DispatchSpawn();
 
     }
 

--- a/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
+++ b/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
@@ -1,0 +1,195 @@
+﻿using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Memory.DynamicFunctions;
+using CounterStrikeSharp.API.Modules.Utils;
+using Jailbreak.Formatting.Extensions;
+using Jailbreak.Formatting.Views;
+using Jailbreak.Public.Behaviors;
+using Jailbreak.Public.Mod.Rebel;
+using System.Runtime.InteropServices;
+
+namespace Jailbreak.Rebel.JihadC4;
+
+public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
+{
+
+    // Importantly the Player argument CAN be null!
+    private class JihadBombMetadata(CCSPlayerController? player, float delay) { public CCSPlayerController? Player { get; set; } = player; public float Delay { get; set; } = delay; }
+
+    private IJihadC4Notifications _jihadNotifications;
+    private BasePlugin _basePlugin;
+
+    // The key represents the active jihad c4, the pair represents the bomb metadata
+    private Dictionary<CC4, JihadBombMetadata> _currentActiveJihadC4s = new();
+
+    // Windows AND Linux... :)
+    private readonly MemoryFunctionVoid<nint, string, int, float, float> CBaseEntity_EmitSoundParams = (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ? new("\\x48\\xB8\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x2A\\x55\\x48\\x89\\xE5\\x41\\x55\\x41\\x54\\x49\\x89\\xFC\\x53\\x48\\x89\\xF3") : new("\\x48\\x8B\\xC4\\x48\\x89\\x58\\x10\\x48\\x89\\x70\\x18\\x55\\x57\\x41\\x56\\x48\\x8D\\xA8\\x08\\xFF\\xFF\\xFF");
+
+    // todo add notification support here
+    public JihadC4Behavior(IJihadC4Notifications jihadC4Notifications)
+    {
+        _jihadNotifications = jihadC4Notifications;   
+    }
+
+    public void Start(BasePlugin basePlugin)
+    {
+        _basePlugin = basePlugin;
+        _basePlugin.RegisterListener<Listeners.OnTick>(PlayerUseC4ListenerCallback);
+    }
+
+   
+
+    // TODO HANDLE WHEN PLAYER LEAVES AND STUFF LIKE THAT
+
+
+    /// <summary>
+    /// Checks when a player attempts to detonate the C4 (by doing +use). This function then handles certain things and calls another function to actually detonte it.
+    /// </summary>
+    private void PlayerUseC4ListenerCallback()
+    {
+
+        foreach (JihadBombMetadata metadata in _currentActiveJihadC4s.Values)
+        {
+            CCSPlayerController? player = metadata.Player;
+            if (player == null) { continue; }
+
+            // is the use button currently active? 
+            if ((player.Buttons & PlayerButtons.Use) == 0) { continue; }
+            Console.WriteLine("2");
+
+            CPlayer_WeaponServices? weaponServices = TryGetWeaponServices(player);
+            if (weaponServices == null || player.PlayerPawn.Value!.WeaponServices!.ActiveWeapon == null || player.PlayerPawn.Value.WeaponServices.ActiveWeapon.Value == null) { continue; }
+
+            // Check if the currently held and "used" item is our C4
+            if (!weaponServices.ActiveWeapon!.Value!.DesignerName.Equals("weapon_c4")) { continue; }
+
+            CC4 bombEntity = new CC4(weaponServices.ActiveWeapon!.Value!.Handle);
+            _currentActiveJihadC4s.Remove(bombEntity);
+            Console.WriteLine("3");
+
+            //player.ExecuteClientCommandFromServer("kill"); UNCOMMENT LATER
+            TryDetonateJihadC4(player, metadata.Delay);
+            Console.WriteLine("4");
+
+            _jihadNotifications.PlayerDetonateC4(player).ToAllChat();
+
+            /**Server.NextFrame(bombEntity.Remove);
+            Console.WriteLine("5");**/ // UNCOMMENT LATER AND LOOK INTO THIS, HOW TO REMOVE C4 AFTER KILL CMD
+
+        }
+    }
+
+    [ConsoleCommand("css_d", "debug cmd")]
+    public void Command_Debug(CCSPlayerController? executor, CommandInfo info)
+    {
+
+        if (executor == null || !executor.IsValid) { return; }
+        TryGiveC4ToPlayer(executor);
+
+    }
+
+    [GameEventHandler]
+    public HookResult OnPlayerDropC4(EventBombDropped @event, GameEventInfo info)
+    {
+        CCSPlayerController? player = @event.Userid;
+        if (player == null || !player.IsValid) { return HookResult.Continue; }
+
+        CC4 bombEntity = Utilities.GetEntityFromIndex<CC4>((int)@event.Entindex);
+
+        // We check this as obviously we're only concerned with C4's that are in our dictionary
+        if (!_currentActiveJihadC4s.ContainsKey(bombEntity)) { return HookResult.Continue; }
+
+        // If a jihad bomb is dropped then the player entry in the dictionary needs to be nulled. We will set it again when another player picks it up.
+        _currentActiveJihadC4s[bombEntity].Player = null;
+        // This requires a nextframe because apparently some Valve functions don't like printing inside of them ??!?!
+        Server.NextFrame(() => { _jihadNotifications.JIHAD_C4_DROPPED.ToPlayerChat(player); });
+
+        return HookResult.Continue;
+
+    }
+
+    [GameEventHandler]
+    public HookResult OnPlayerPickupC4(EventBombPickup @event, GameEventInfo info)
+    {
+        CCSPlayerController? player = @event.Userid;
+        if (player == null || !player.IsValid) { return HookResult.Continue; }
+
+        CPlayer_WeaponServices? weaponServices = TryGetWeaponServices(player);
+        if (weaponServices == null) { Console.WriteLine("Weaponservice was null in OnPlayerPickupC4"); return HookResult.Continue; }
+
+        CC4 bombEntity = new CC4(weaponServices.MyWeapons.Last()!.Value!.Handle); // The last item in the weapons list is the last item to be picked up, apparently...
+        if (!_currentActiveJihadC4s.ContainsKey(bombEntity)) { return HookResult.Continue; }
+
+        _currentActiveJihadC4s[bombEntity].Player = player;
+        _jihadNotifications.JIHAD_C4_PICKUP.ToPlayerChat(player);
+
+        return HookResult.Continue;
+
+    }
+
+    [GameEventHandler]
+    public HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
+    {
+        _currentActiveJihadC4s.Clear();
+        return HookResult.Continue;
+    }
+
+    public void TryGiveC4ToPlayer(CCSPlayerController player)
+    {
+        CC4 bombEntity = new CC4(player.GiveNamedItem("weapon_c4"));
+        _currentActiveJihadC4s[bombEntity] = new JihadBombMetadata(player, 1.0f);
+        _jihadNotifications.JIHAD_C4_RECEIVED.ToPlayerChat(player);
+    }
+
+    // Not using _notifications.PlayerDetonateC4() here, as I invoked that in the +use callback already
+    public void TryDetonateJihadC4(CCSPlayerController player, float delay)
+    {
+        /* PARTICLE EXPLOSION */
+        CParticleSystem particleSystemEntity = Utilities.CreateEntityByName<CParticleSystem>("info_particle_system")!;
+        particleSystemEntity.EffectName = "particles/explosions_fx/explosion_c4_500.vpcf";
+        particleSystemEntity.StartActive = true;
+
+        particleSystemEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin!, new QAngle(), new Vector());
+        particleSystemEntity.DispatchSpawn();
+
+        /* PHYS EXPLPOSION, FOR PUSHING PLAYERS */
+        CPhysExplosion envPhysExplosionEntity = Utilities.CreateEntityByName<CPhysExplosion>("env_physexplosion")!;
+
+        envPhysExplosionEntity.Spawnflags = 1 << 1;
+
+        envPhysExplosionEntity.Magnitude = 50f;
+        envPhysExplosionEntity.Damage = 0f;
+        envPhysExplosionEntity.Radius = 0f; // clampradius ? 
+        envPhysExplosionEntity.InnerRadius = 0f;
+        envPhysExplosionEntity.PushScale = 10f;
+
+        envPhysExplosionEntity.ConvertToDebrisWhenPossible = false;
+        envPhysExplosionEntity.ExplodeOnSpawn = true;
+
+        envPhysExplosionEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin!, new QAngle(), new Vector());
+        envPhysExplosionEntity.DispatchSpawn();
+
+        /* ENV_EXPLOSION, FOR DAMAGING PLAYERS, LIKE BOMB BLAST IN CS2 */
+        /**CEnvExplosion envExplosionEntity = Utilities.CreateEntityByName<CEnvExplosion>("env_explosion")!;
+
+        envExplosionEntity.Magnitude = 50;
+        envExplosionEntity.RadiusOverride = 0;
+        envExplosionEntity.RenderMode = RenderMode_t.kRenderNormal;
+
+        envExplosionEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin, new QAngle(), new Vector());
+        envExplosionEntity.DispatchSpawn();
+
+        envExplosionEntity.AcceptInput("Explode");**/
+
+    }
+
+    private CPlayer_WeaponServices? TryGetWeaponServices(CCSPlayerController? player)
+    {
+        if (player == null) { return null; }
+        if (player.PlayerPawn == null || player.PlayerPawn.Value == null || player.PlayerPawn.Value.WeaponServices == null) { return null; }
+        return player.PlayerPawn.Value.WeaponServices;
+    }
+
+}

--- a/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
+++ b/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
@@ -60,20 +60,24 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
             Console.WriteLine("2");
 
             CPlayer_WeaponServices? weaponServices = TryGetWeaponServices(player);
-            if (weaponServices == null || player.PlayerPawn.Value!.WeaponServices!.ActiveWeapon == null || player.PlayerPawn.Value.WeaponServices.ActiveWeapon.Value == null) { continue; }
-
+            if (weaponServices == null || weaponServices.ActiveWeapon == null || weaponServices.ActiveWeapon.Value == null || !weaponServices.ActiveWeapon.Value.IsValid) { continue; }
+            Console.WriteLine("2.1??");
             // Check if the currently held and "used" item is our C4
             if (!weaponServices.ActiveWeapon!.Value!.DesignerName.Equals("weapon_c4")) { continue; }
+            Console.WriteLine("2.2");
 
             CC4 bombEntity = new CC4(weaponServices.ActiveWeapon!.Value!.Handle);
-            _currentActiveJihadC4s.Remove(bombEntity);
+            Console.WriteLine("is bomb valid tho: " + bombEntity.IsValid);
+            // _currentActiveJihadC4s.Remove(bombEntity); DEBUG1
             Console.WriteLine("3");
 
             //player.ExecuteClientCommandFromServer("kill"); UNCOMMENT LATER
-            TryDetonateJihadC4(player, metadata.Delay);
+            //TryDetonateJihadC4(player, metadata.Delay);
             Console.WriteLine("4");
 
-            _jihadNotifications.PlayerDetonateC4(player).ToAllChat();
+            //_jihadNotifications.PlayerDetonateC4(player).ToAllChat();
+
+            // todo next frame print chat
 
             /**Server.NextFrame(bombEntity.Remove);
             Console.WriteLine("5");**/ // UNCOMMENT LATER AND LOOK INTO THIS, HOW TO REMOVE C4 AFTER KILL CMD
@@ -147,41 +151,24 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
     public void TryDetonateJihadC4(CCSPlayerController player, float delay)
     {
         /* PARTICLE EXPLOSION */
-        CParticleSystem particleSystemEntity = Utilities.CreateEntityByName<CParticleSystem>("info_particle_system")!;
+        /**CParticleSystem particleSystemEntity = Utilities.CreateEntityByName<CParticleSystem>("info_particle_system")!;
         particleSystemEntity.EffectName = "particles/explosions_fx/explosion_c4_500.vpcf";
         particleSystemEntity.StartActive = true;
 
         particleSystemEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin!, new QAngle(), new Vector());
-        particleSystemEntity.DispatchSpawn();
+        particleSystemEntity.DispatchSpawn();**/
 
         /* PHYS EXPLPOSION, FOR PUSHING PLAYERS */
-        CPhysExplosion envPhysExplosionEntity = Utilities.CreateEntityByName<CPhysExplosion>("env_physexplosion")!;
+        /**CPhysExplosion envPhysExplosionEntity = Utilities.CreateEntityByName<CPhysExplosion>("env_physexplosion")!;
 
         envPhysExplosionEntity.Spawnflags = 1 << 1;
-
-        envPhysExplosionEntity.Magnitude = 50f;
-        envPhysExplosionEntity.Damage = 0f;
-        envPhysExplosionEntity.Radius = 0f; // clampradius ? 
-        envPhysExplosionEntity.InnerRadius = 0f;
-        envPhysExplosionEntity.PushScale = 10f;
-
-        envPhysExplosionEntity.ConvertToDebrisWhenPossible = false;
         envPhysExplosionEntity.ExplodeOnSpawn = true;
+        envPhysExplosionEntity.Magnitude = 50f;
+        envPhysExplosionEntity.PushScale = 3.5f;
+        envPhysExplosionEntity.Radius = 340f; // As per old code.
 
-        envPhysExplosionEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin!, new QAngle(), new Vector());
-        envPhysExplosionEntity.DispatchSpawn();
-
-        /* ENV_EXPLOSION, FOR DAMAGING PLAYERS, LIKE BOMB BLAST IN CS2 */
-        /**CEnvExplosion envExplosionEntity = Utilities.CreateEntityByName<CEnvExplosion>("env_explosion")!;
-
-        envExplosionEntity.Magnitude = 50;
-        envExplosionEntity.RadiusOverride = 0;
-        envExplosionEntity.RenderMode = RenderMode_t.kRenderNormal;
-
-        envExplosionEntity.Teleport(player.PlayerPawn!.Value!.AbsOrigin, new QAngle(), new Vector());
-        envExplosionEntity.DispatchSpawn();
-
-        envExplosionEntity.AcceptInput("Explode");**/
+        envPhysExplosionEntity.Teleport(player.PlayerPawn.Value!.AbsOrigin!, new QAngle(), new Vector());
+        envPhysExplosionEntity.DispatchSpawn();**/
 
     }
 

--- a/mod/Jailbreak.Rebel/RebelManager.cs
+++ b/mod/Jailbreak.Rebel/RebelManager.cs
@@ -6,7 +6,6 @@ using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
-using Jailbreak.Public.Mod.Logs;
 using Jailbreak.Public.Mod.Rebel;
 
 namespace Jailbreak.Rebel;

--- a/mod/Jailbreak.Rebel/RebelServiceExtension.cs
+++ b/mod/Jailbreak.Rebel/RebelServiceExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Jailbreak.Public.Extensions;
 using Jailbreak.Public.Mod.Rebel;
+using Jailbreak.Rebel.JihadC4;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jailbreak.Rebel;
@@ -9,6 +10,7 @@ public static class RebelServiceExtension
     public static void AddJailbreakRebel(this IServiceCollection collection)
     {
         collection.AddPluginBehavior<IRebelService, RebelManager>();
+        collection.AddPluginBehavior<IJihadC4Service, JihadC4Behavior>();
         collection.AddPluginBehavior<RebelListener>();
     }
 }

--- a/public/Jailbreak.Formatting/Logistics/LanguageConfig.cs
+++ b/public/Jailbreak.Formatting/Logistics/LanguageConfig.cs
@@ -31,7 +31,11 @@ public class LanguageConfig<TDialect>
 		where TRebel : class, ILanguage<TDialect>, IRebelNotifications
 		=> _collection.AddSingleton<IRebelNotifications, TRebel>();
 
-	public void WithLogging<TLogging>()
+    public void WithJihadC4<TJihadC4>()
+		where TJihadC4 : class, ILanguage<TDialect>, IJihadC4Notifications
+		=> _collection.AddSingleton<IJihadC4Notifications, TJihadC4>();
+
+    public void WithLogging<TLogging>()
 		where TLogging : class, ILanguage<TDialect>, ILogMessages
 		=> _collection.AddSingleton<ILogMessages, TLogging>();
 

--- a/public/Jailbreak.Formatting/Views/IJihadC4Notifications.cs
+++ b/public/Jailbreak.Formatting/Views/IJihadC4Notifications.cs
@@ -1,0 +1,19 @@
+﻿using CounterStrikeSharp.API.Core;
+using Jailbreak.Formatting.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jailbreak.Formatting.Views;
+
+public interface IJihadC4Notifications
+{
+
+    public IView PlayerDetonateC4(CCSPlayerController player);
+    public IView JIHAD_C4_DROPPED { get; }
+    public IView JIHAD_C4_PICKUP { get; }
+    public IView JIHAD_C4_RECEIVED { get; }
+
+}

--- a/public/Jailbreak.Public/Jailbreak.Public.csproj
+++ b/public/Jailbreak.Public/Jailbreak.Public.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.202"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.0"/>
+        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.213" />
+        <PackageReference Include="System.Text.Json" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Plugin\"/>
+        <Folder Include="Plugin\" />
     </ItemGroup>
 
 </Project>

--- a/public/Jailbreak.Public/Mod/Rebel/IJihadC4Service.cs
+++ b/public/Jailbreak.Public/Mod/Rebel/IJihadC4Service.cs
@@ -1,0 +1,20 @@
+﻿using CounterStrikeSharp.API.Core;
+
+namespace Jailbreak.Public.Mod.Rebel;
+
+public interface IJihadC4Service
+{
+
+    /// <summary>
+    /// Tries to give the jihad C4 to the player, assuming the player object passed in is valid.
+    /// </summary>
+    /// <param name="player"></param>
+    void TryGiveC4ToPlayer(CCSPlayerController player);
+
+    /// <summary>
+    /// Tries to detonate the jihad c4, relative to the player's position after the delay.
+    /// </summary>
+    /// <param name="player"></param>
+    void TryDetonateJihadC4(CCSPlayerController player, float delay);
+
+}

--- a/src/Jailbreak/Jailbreak.cs
+++ b/src/Jailbreak/Jailbreak.cs
@@ -45,6 +45,12 @@ public class Jailbreak : BasePlugin
 
         Logger.LogInformation("[Jailbreak] Found {@BehaviorCount} behaviors.", _extensions.Count);
 
+        // Precache particles needed for features like Jihad C4 
+        RegisterListener<Listeners.OnServerPrecacheResources>((manifest) =>
+        {
+            manifest.AddResource("particles/explosions_fx/explosion_c4_500.vpcf");
+        });
+
         foreach (var extension in _extensions)
         {
             //	Register all event handlers on the extension object

--- a/src/Jailbreak/JailbreakServiceCollection.cs
+++ b/src/Jailbreak/JailbreakServiceCollection.cs
@@ -47,6 +47,7 @@ public class JailbreakServiceCollection : IPluginServiceCollection<Jailbreak>
 			config.WithGenericCommand<GenericCommandNotifications>();
 			config.WithWarden<WardenNotifications>();
 			config.WithRebel<RebelNotifications>();
+            config.WithJihadC4<JihadC4Notifications>();
 			config.WithLogging<LogMessages>();
 			config.WithLastRequest<LastRequestMessages>();
 			config.WithSpecialTreatment<SpecialTreatmentNotifications>();


### PR DESCRIPTION
This PR is for a fully working Jihad C4 system (UNFINISHED). The code is commented for easy reading. 

Completed: 
- Ability to give, pass on (drop), and detonate Jihad C4's
- Notifications support
- LATEST version (v213) of CS#
- When a player dies the jihad C4 is dropped and is still useable
- Spawn an env_physexplosion so that the bomb pushes players when detonated 

TODO:
- Add EmitSound support (signature is found, I need to integrate it with jii's JB eGO assets addon)
- Actually do damage to players when C4 is detonated (either with old code's formula or env_explosion entity)
- Create code that integrates with other JB code to give a random player the Jihad C4 at the start of the round!