### PR TITLE
Fixes damage LR rules. Moves all CBaseEntity_TakeDamageOldFunc to be handled by EventPlayerHurt

### DIFF
--- a/lang/Jailbreak.English/LastRequest/LastRequestMessages.cs
+++ b/lang/Jailbreak.English/LastRequest/LastRequestMessages.cs
@@ -86,4 +86,7 @@ public class LastRequestMessages : ILastRequestMessages, ILanguage<Formatting.La
             result == LRResult.PrisonerWin ? lr.prisoner : lr.guard, "won the LR."
         };
     }
+
+    public IView DamageBlockedInsideLastRequest => new SimpleView { PREFIX, "You or they are in LR, damage blocked." };
+    public IView DamageBlockedNotInSameLR => new SimpleView { PREFIX, "You are not in the same LR as them, damage blocked." };
 }

--- a/mod/Jailbreak.SpecialDay/SpecialDayHandler.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDayHandler.cs
@@ -4,6 +4,7 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Behaviors;
+using Jailbreak.Public.Mod.Damage;
 using Jailbreak.Public.Mod.SpecialDays;
 
 namespace Jailbreak.SpecialDay;
@@ -19,6 +20,7 @@ public class SpecialDayHandler(SpecialDayConfig config) : ISpecialDayHandler, IP
     {
         plugin.RegisterEventHandler<EventRoundEnd>(OnRoundEnd);
         plugin.RegisterEventHandler<EventRoundStart>(OnRoundStart);
+        plugin.RegisterEventHandler<EventPlayerHurt>(DamageHandler);
         _plugin = plugin;
     }
 
@@ -32,17 +34,31 @@ public class SpecialDayHandler(SpecialDayConfig config) : ISpecialDayHandler, IP
 
         _currentSpecialDay = null;
         _roundsSinceLastSpecialDay = 0;
-        
+
         return HookResult.Continue;
     }
-    
+
+    [GameEventHandler(HookMode.Pre)]
+    private HookResult DamageHandler(EventPlayerHurt @event, GameEventInfo info)
+    {
+        if (_currentSpecialDay == null)
+        {
+            return HookResult.Continue;
+        }
+        if (_currentSpecialDay is IBlockUserDamage damageHandler)
+        {
+            return damageHandler.BlockUserDamage(@event, info);
+        }
+        return HookResult.Continue;
+    }
+
     [GameEventHandler]
     private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
         _roundsSinceLastSpecialDay++;
         return HookResult.Continue;
     }
-    
+
     public int RoundsSinceLastSpecialDay()
     {
         return _roundsSinceLastSpecialDay;
@@ -61,25 +77,25 @@ public class SpecialDayHandler(SpecialDayConfig config) : ISpecialDayHandler, IP
     public bool StartSpecialDay<ISpecialDayNotifications>(string name, ISpecialDayNotifications _notifications)
     {
         if (_isSpecialDayActive || !CanStartSpecialDay()) return false;
-        
+
         var fullName = "Jailbreak.SpecialDay.SpecialDays";
         var q = from t in Assembly.GetExecutingAssembly().GetTypes()
-            where t.IsClass && t.Namespace == fullName && t.GetInterface("ISpecialDay") != null
-            select t;
+                where t.IsClass && t.Namespace == fullName && t.GetInterface("ISpecialDay") != null
+                select t;
 
         foreach (var type in q)
         {
             if (type == null) continue;
-            var item = (ISpecialDay) Activator.CreateInstance(type, _plugin, _notifications);
+            var item = (ISpecialDay)Activator.CreateInstance(type, _plugin, _notifications);
             if (item == null) continue;
             if (item.Name != name) continue;
-            
+
             _currentSpecialDay = item;
             _isSpecialDayActive = true;
             _currentSpecialDay.OnStart();
             break;
         }
-        
+
         //Server.NextFrame(() => Server.PrintToChatAll($"{_currentSpecialDay?.Name} has started - {_currentSpecialDay?.Description}"));
         return true;
     }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/FreeForAllDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/FreeForAllDay.cs
@@ -1,5 +1,6 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Cvars;
 using CounterStrikeSharp.API.Modules.Memory;
 using CounterStrikeSharp.API.Modules.Timers;
@@ -7,13 +8,14 @@ using CounterStrikeSharp.API.Modules.Utils;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.Damage;
 using Jailbreak.Public.Mod.SpecialDays;
 using Jailbreak.Public.Utils;
 using Timer = CounterStrikeSharp.API.Modules.Timers.Timer;
 
 namespace Jailbreak.SpecialDay.SpecialDays;
 
-public class FreeForAllDay : ISpecialDay
+public class FreeForAllDay : ISpecialDay, IBlockUserDamage
 {
     public string Name => "Warday";
     public string Description => "Everyone for themselves. Your goal is to be the last man standing!";
@@ -28,8 +30,17 @@ public class FreeForAllDay : ISpecialDay
     {
         _notifications = notifications;
         _plugin = plugin;
-        VirtualFunctions.CBaseEntity_TakeDamageOldFunc.Hook(_ => _hasStarted ? HookResult.Continue : HookResult.Stop, HookMode.Pre);    }
-    
+    }
+
+    public bool ShouldBlockDamage(CCSPlayerController player, CCSPlayerController? attacker, EventPlayerHurt @event)
+    {
+        if (_hasStarted)
+        {
+            return false;
+        }
+        return true;
+    }
+
     public void OnStart()
     {
         _notifications.SD_FFA_STARTED
@@ -41,26 +52,27 @@ public class FreeForAllDay : ISpecialDay
                      .Where(player => player.IsReal()))
         {
             var max = spawn.Count;
-            
+
             var index = new Random().Next(0, max);
-            
+
             player.PlayerPawn.Value!.Teleport(spawn[index].AbsOrigin);
             FreezeManager.FreezePlayer(player, 3);
         }
-        
+
         var friendlyFire = ConVar.Find("mp_friendlyfire");
         var teammates = ConVar.Find("mp_teammates_are_enemies");
 
         if (friendlyFire == null) return;
-        
+
         var friendlyFireValue = friendlyFire.GetPrimitiveValue<bool>(); //assume false in this example, use GetNativeValue for vectors, Qangles, etc
-        
-        if (!friendlyFireValue) {
+
+        if (!friendlyFireValue)
+        {
             friendlyFire.SetValue<bool>(true);
         }
-        
+
         if (teammates == null) return;
-        
+
         teammates.SetValue<bool>(true);
 
         _hasStarted = false;
@@ -72,27 +84,28 @@ public class FreeForAllDay : ISpecialDay
         timer1 = _plugin.AddTimer(1f, () =>
         {
             timer++;
-            
+
             if (timer != 15) return;
-            
+
             _hasStarted = true;
-            
+
             timer1.Kill();
         }, TimerFlags.REPEAT);
-        
+
     }
 
     public void OnEnd()
     {
-        
+
         var friendlyFire = ConVar.Find("mp_friendlyfire");
         var teammates = ConVar.Find("mp_teammates_are_enemies");
 
         if (friendlyFire == null) return;
-        
+
         var friendlyFireValue = friendlyFire.GetPrimitiveValue<bool>(); //assume false in this example, use GetNativeValue for vectors, Qangles, etc
-        
-        if (friendlyFireValue) {
+
+        if (friendlyFireValue)
+        {
             friendlyFire?.SetValue<bool>(false);
         }
 

--- a/mod/Jailbreak.SpecialDay/SpecialDays/Warday.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/Warday.cs
@@ -1,11 +1,13 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Memory;
 using CounterStrikeSharp.API.Modules.Timers;
 using CounterStrikeSharp.API.Modules.Utils;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.Damage;
 using Jailbreak.Public.Mod.SpecialDays;
 using Jailbreak.Public.Utils;
 using Microsoft.VisualBasic.CompilerServices;
@@ -13,7 +15,7 @@ using Timer = CounterStrikeSharp.API.Modules.Timers.Timer;
 
 namespace Jailbreak.SpecialDay.SpecialDays;
 
-public class Warday : ISpecialDay
+public class Warday : ISpecialDay, IBlockUserDamage
 {
     public string Name => "Warday";
     public string Description => $" {ChatColors.Red}[Warday] {ChatColors.Blue} Guards versus Prisoners. Your goal is to ensure that your team is last team standing!";
@@ -28,8 +30,17 @@ public class Warday : ISpecialDay
     {
         _notifications = notifications;
         _plugin = plugin;
-        VirtualFunctions.CBaseEntity_TakeDamageOldFunc.Hook(_ => _hasStarted ? HookResult.Continue : HookResult.Stop, HookMode.Pre);    }
-    
+    }
+
+    public bool ShouldBlockDamage(CCSPlayerController player, CCSPlayerController? attacker, EventPlayerHurt @event)
+    {
+        if (_hasStarted)
+        {
+            return false;
+        }
+        return true;
+    }
+
     public void OnStart()
     {
         _notifications.SD_WARDAY_STARTED
@@ -52,17 +63,17 @@ public class Warday : ISpecialDay
         timer1 = _plugin.AddTimer(1f, () =>
         {
             timer++;
-                
+
             if (timer != 30) return;
             _hasStarted = true;
             timer1.Kill();
         }, TimerFlags.REPEAT);
-        
+
     }
 
     public void OnEnd()
     {
         //do nothing for now
     }
-    
+
 }

--- a/public/Jailbreak.Formatting/Extensions/ViewExtensions.cs
+++ b/public/Jailbreak.Formatting/Extensions/ViewExtensions.cs
@@ -10,32 +10,32 @@ namespace Jailbreak.Formatting.Extensions;
 public static class ViewExtensions
 {
 
-	public static FormatWriter ToWriter(this IView view)
-	{
-		var writer = new FormatWriter();
+    public static FormatWriter ToWriter(this IView view)
+    {
+        var writer = new FormatWriter();
 
-		view.Render(writer);
+        view.Render(writer);
 
-		return writer;
-	}
+        return writer;
+    }
 
-	public static IView ToServerConsole(this IView view)
-	{
-		var writer = view.ToWriter();
+    public static IView ToServerConsole(this IView view)
+    {
+        var writer = view.ToWriter();
 
-		foreach (string s in writer.Plain)
-		{
-			Server.PrintToConsole(s);
-		}
+        foreach (string s in writer.Plain)
+        {
+            Server.PrintToConsole(s);
+        }
 
-		return view;
-	}
+        return view;
+    }
 
-	#region Individual
+    #region Individual
 
     public static IView ToPlayerConsole(this IView view, CCSPlayerController player)
     {
-        if(!player.IsReal())
+        if (!player.IsReal() || player.IsBot)
             return view;
 
         var writer = view.ToWriter();
@@ -48,7 +48,7 @@ public static class ViewExtensions
 
     public static IView ToPlayerChat(this IView view, CCSPlayerController player)
     {
-        if(!player.IsReal())
+        if (!player.IsReal() || player.IsBot)
             return view;
 
         var writer = view.ToWriter();
@@ -61,7 +61,7 @@ public static class ViewExtensions
 
     public static IView ToPlayerCenter(this IView view, CCSPlayerController player)
     {
-        if(!player.IsReal())
+        if (!player.IsReal() || player.IsBot)
             return view;
 
         var writer = view.ToWriter();
@@ -74,7 +74,7 @@ public static class ViewExtensions
 
     public static IView ToPlayerCenterHtml(this IView view, CCSPlayerController player)
     {
-        if(!player.IsReal())
+        if (!player.IsReal() || player.IsBot)
             return view;
 
         var writer = view.ToWriter();
@@ -85,26 +85,26 @@ public static class ViewExtensions
         return view;
     }
 
-	#endregion
+    #endregion
 
-	public static IView ToAllConsole(this IView view)
-	{
-		Utilities.GetPlayers().ForEach(player => view.ToPlayerConsole(player));
+    public static IView ToAllConsole(this IView view)
+    {
+        Utilities.GetPlayers().ForEach(player => view.ToPlayerConsole(player));
 
-		return view;
-	}
+        return view;
+    }
 
-	public static IView ToAllChat(this IView view)
-	{
-		Utilities.GetPlayers().ForEach(player => view.ToPlayerChat(player));
+    public static IView ToAllChat(this IView view)
+    {
+        Utilities.GetPlayers().ForEach(player => view.ToPlayerChat(player));
 
-		return view;
-	}
+        return view;
+    }
 
-	public static IView ToAllCenter(this IView view)
-	{
-		Utilities.GetPlayers().ForEach(player => view.ToPlayerCenter(player));
+    public static IView ToAllCenter(this IView view)
+    {
+        Utilities.GetPlayers().ForEach(player => view.ToPlayerCenter(player));
 
-		return view;
-	}
+        return view;
+    }
 }

--- a/public/Jailbreak.Formatting/Views/ILastRequestMessages.cs
+++ b/public/Jailbreak.Formatting/Views/ILastRequestMessages.cs
@@ -15,4 +15,6 @@ public interface ILastRequestMessages
     public IView InformLastRequest(AbstractLastRequest lr);
     public IView AnnounceLastRequest(AbstractLastRequest lr);
     public IView LastRequestDecided(AbstractLastRequest lr, LRResult result);
+    public IView DamageBlockedInsideLastRequest { get; }
+    public IView DamageBlockedNotInSameLR { get; }
 }

--- a/public/Jailbreak.Public/Extensions/PlayerExtensions.cs
+++ b/public/Jailbreak.Public/Extensions/PlayerExtensions.cs
@@ -24,7 +24,7 @@ public static class PlayerExtensions
         if (player.Connected != PlayerConnectedState.PlayerConnected)
             return false;
 
-        if (player.IsBot || player.IsHLTV)
+        if (player.IsHLTV)
             return false;
 
         return true;

--- a/public/Jailbreak.Public/Mod/Damage/IBlockAllDamage.cs
+++ b/public/Jailbreak.Public/Mod/Damage/IBlockAllDamage.cs
@@ -1,0 +1,31 @@
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using Jailbreak.Public.Extensions;
+
+namespace Jailbreak.Public.Mod.Damage;
+
+public interface IBlockUserDamage
+{
+    HookResult BlockUserDamage(EventPlayerHurt @event, GameEventInfo info)
+    {
+        var player = @event.Userid;
+        var attacker = @event.Attacker;
+        if (player == null || !player.IsReal())
+            return HookResult.Continue;
+
+        if (!ShouldBlockDamage(player, attacker, @event))
+        {
+            return HookResult.Continue;
+        }
+        if (player.PlayerPawn.IsValid)
+        {
+            CCSPlayerPawn playerPawn = player.PlayerPawn.Value!;
+            playerPawn.Health = playerPawn.LastHealth;
+        }
+        @event.DmgArmor = 0;
+        @event.DmgHealth = 0;
+        return HookResult.Stop;
+    }
+
+    bool ShouldBlockDamage(CCSPlayerController victim, CCSPlayerController? attacker, EventPlayerHurt @event);
+}


### PR DESCRIPTION
As the title says.
Damage LR rules are fixed, so that if you are in an LR, you can't damage non-LR participants and people not related to your LR.

CBaseEntity_TakeDamageOldFunc has broken signatures on windows and constantly causes crashes. I could track down the correct signatures, but I think moving this instead to use the CounterStrikeSharp event handlers is a better idea. Let me know if there's some specific reason to be using CBaseEntity_TakeDamageOldFunc instead.

New implementation works by just setting a player's health to their old health. On testing, this works fine and prevents deaths that may instantly kill the player too (i.e. headshots). Video can be seen down below.

https://github.com/edgegamers/Jailbreak/assets/37270891/d6bf9c64-183a-4882-9b81-bc4460d40447

Also made bots treatable as players. Let me know if I should undo this but it just made testing these changes a lot easier.