### PR TITLE
Sets listen override for all players to ListenOverride.Hear on roundstart. Maybe fixes micbug, probably not.

### DIFF
--- a/mod/Jailbreak.Mute/MuteSystem.cs
+++ b/mod/Jailbreak.Mute/MuteSystem.cs
@@ -3,7 +3,6 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Utils;
-using Jailbreak.Formatting.Base;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Public.Behaviors;

--- a/mod/Jailbreak.Mute/MuteSystem.cs
+++ b/mod/Jailbreak.Mute/MuteSystem.cs
@@ -107,7 +107,7 @@ public class MuteSystem(IServiceProvider provider) : IPluginBehavior, IMuteServi
                 {
                     continue;
                 }
-                player.SetListenOverride(target, ListenOverride.Default);
+                player.SetListenOverride(target, ListenOverride.Hear);
             }
         }
         return HookResult.Continue;

--- a/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
+++ b/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
@@ -189,10 +189,7 @@ public class JihadC4Behavior : IPluginBehavior, IJihadC4Service
 
     private void TryEmitSound(CBaseEntity entity, string soundEventName, int pitch, float volume, float delay)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            CBaseEntity_EmitSoundParamsLinux.Invoke(entity, soundEventName, pitch, volume, delay);
-        }
+        CBaseEntity_EmitSoundParamsLinux.Invoke(entity, soundEventName, pitch, volume, delay);
     }
 
     // Returns whether the weapon c4 was in their inventory or not.

--- a/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
+++ b/mod/Jailbreak.Rebel/JihadC4/JihadC4Behavior.cs
@@ -10,7 +10,6 @@ using Jailbreak.Public.Extensions;
 using Jailbreak.Public.Mod.Rebel;
 using Microsoft.Extensions.Logging;
 using Jailbreak.Public.Mod.SpecialDays;
-using System.Runtime.InteropServices;
 
 namespace Jailbreak.Rebel.JihadC4;
 


### PR DESCRIPTION
Sets the ListenOverride for every player on every other player to the 'hear' value. Also gives everyone the VoiceFlags.ListenAll | VoiceFlags.ListenTeam flags.

It's possible that this'll do nothing, but it could act as a bandaid fix for the mic bug that happens when the map changes, which prevents you from hearing what anyone else is saying.

In any case, I can't test this on a local server since it requires another person to see if it actually did anything. I think it's worth trying to see if it does anything and testing it should be trivial. Steps would look something like this.

1. Two players join a server.
2. Force map change.
3. One of them tries speaking over mic, see if the other can hear.

It's a shot in the dark but it doesn't seem like valve is going to do anything to fix this problem so it's worth trying what we can. It's possible this could introduce other problems like being able to hear people who are supposed to be muted, etc, so those will need to be checked too.

The changes have been tested on a local and it doesn't seem to cause any problems.