### PR TITLE
Guaranteed Warden Fix, Weapon Restriction Reversion, and Auto-Open Enhancements in Jailbreak

### DIFF
--- a/lang/Jailbreak.English/Warden/WardenCmdOpenLocale.cs
+++ b/lang/Jailbreak.English/Warden/WardenCmdOpenLocale.cs
@@ -37,9 +37,9 @@ public class WardenCmdOpenLocale : IWardenCmdOpenLocale,
   public IView CellsOpenedWithPrisoners(int prisoners) {
     return new SimpleView {
       WardenLocale.PREFIX,
-      "Detected",
+      ChatColors.Grey + "Detected",
       prisoners,
-      ChatColors.Green + "prisoner" + (prisoners == 1 ? "" : "s")
+      ChatColors.Grey + "prisoner" + (prisoners == 1 ? "" : "s")
       + " still in cells, opening..."
     };
   }
@@ -47,7 +47,7 @@ public class WardenCmdOpenLocale : IWardenCmdOpenLocale,
   public IView CellsOpenedSnitchPrisoners(int prisoners) {
     return new SimpleView {
       WardenLocale.PREFIX,
-      "Detected",
+      ChatColors.Grey + "Detected",
       prisoners,
       ChatColors.Green + "prisoner" + (prisoners == 1 ? "" : "s")
       + " still in cells..."

--- a/lang/Jailbreak.English/Warden/WardenCmdOpenLocale.cs
+++ b/lang/Jailbreak.English/Warden/WardenCmdOpenLocale.cs
@@ -34,6 +34,26 @@ public class WardenCmdOpenLocale : IWardenCmdOpenLocale,
       WardenLocale.PREFIX, ChatColors.Grey + "Cells were auto-opened."
     };
 
+  public IView CellsOpenedWithPrisoners(int prisoners) {
+    return new SimpleView {
+      WardenLocale.PREFIX,
+      "Detected",
+      prisoners,
+      ChatColors.Green + "prisoner" + (prisoners == 1 ? "" : "s")
+      + " still in cells, opening..."
+    };
+  }
+
+  public IView CellsOpenedSnitchPrisoners(int prisoners) {
+    return new SimpleView {
+      WardenLocale.PREFIX,
+      "Detected",
+      prisoners,
+      ChatColors.Green + "prisoner" + (prisoners == 1 ? "" : "s")
+      + " still in cells..."
+    };
+  }
+
   public IView OpeningFailed
     => new SimpleView { WardenLocale.PREFIX, "Failed to open the cells." };
 }

--- a/mod/Jailbreak.Mute/MuteSystem.cs
+++ b/mod/Jailbreak.Mute/MuteSystem.cs
@@ -61,7 +61,6 @@ public class MuteSystem(IServiceProvider provider)
 
   public void UnPeaceMute() {
     if (guardTimer != null) unmuteGuards();
-
     if (prisonerTimer != null) unmutePrisoners();
   }
 
@@ -85,6 +84,7 @@ public class MuteSystem(IServiceProvider provider)
   [GameEventHandler]
   public HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info) {
     UnPeaceMute();
+    foreach (var player in Utilities.GetPlayers()) unmute(player);
     return HookResult.Continue;
   }
 

--- a/mod/Jailbreak.RTD/Rewards/CannotPickupReward.cs
+++ b/mod/Jailbreak.RTD/Rewards/CannotPickupReward.cs
@@ -6,50 +6,37 @@ using Jailbreak.Public.Mod.RTD;
 
 namespace Jailbreak.RTD.Rewards;
 
-public class CannotPickupReward : IRTDReward {
-  private readonly HashSet<int> blockedPlayerIDs = [];
+public class CannotPickupReward : AbstractOnTickReward {
   private readonly ImmutableHashSet<string> blockedWeapons;
 
   public CannotPickupReward(BasePlugin plugin, WeaponType blocked) : this(
     plugin, blocked.GetItems().ToArray()) {
-    NameShort = blocked.ToString();
+    NameShort = blocked.ToString().ToTitleCase();
   }
 
-  public CannotPickupReward(BasePlugin plugin, params string[] weapons) {
-    plugin.RegisterEventHandler<EventItemPickup>(onPickup);
-    plugin.RegisterEventHandler<EventRoundEnd>(onRoundEnd);
-
+  public CannotPickupReward(BasePlugin plugin, params string[] weapons) : base(
+    plugin) {
     blockedWeapons = weapons.ToImmutableHashSet();
     NameShort = string.Join(", ",
       blockedWeapons.Select(s => s.GetFriendlyWeaponName()));
   }
 
-  public virtual string Name => $"Cannot Pickup {NameShort}";
+  public override string Name => $"Cannot Use {NameShort}";
   public string NameShort { get; }
 
-  public virtual string Description
-    => $"You will not be able to pickup {NameShort} next round.";
+  public override string Description
+    => $"You will not be able to use {NameShort} next round.";
 
-  public bool GrantReward(CCSPlayerController player) {
-    if (player.UserId == null) return false;
-    blockedPlayerIDs.Add(player.UserId.Value);
-    return true;
-  }
-
-  private HookResult onRoundEnd(EventRoundEnd @event, GameEventInfo info) {
-    blockedPlayerIDs.Clear();
-    return HookResult.Continue;
-  }
-
-  private HookResult onPickup(EventItemPickup @event, GameEventInfo info) {
-    var player = @event.Userid;
-    if (player == null || !player.IsValid || player.UserId == null)
-      return HookResult.Continue;
-    if (!blockedPlayerIDs.Contains(player.UserId.Value))
-      return HookResult.Continue;
-    var weapon = "weapon_" + @event.Item;
-    if (!blockedWeapons.Contains(weapon)) return HookResult.Continue;
-    player.RemoveWeapons();
-    return HookResult.Continue;
+  override protected void tick(CCSPlayerController player) {
+    if (!player.IsReal()) return;
+    var pawn = player.PlayerPawn.Value;
+    if (pawn == null || !pawn.IsValid) return;
+    var weaponServices = pawn.WeaponServices;
+    if (weaponServices == null) return;
+    var activeWeapon = weaponServices.ActiveWeapon.Value;
+    if (activeWeapon == null || !activeWeapon.IsValid) return;
+    if (!blockedWeapons.Contains(activeWeapon.DesignerName)) return;
+    activeWeapon.NextPrimaryAttackTick   = Server.TickCount + 500;
+    activeWeapon.NextSecondaryAttackTick = Server.TickCount + 500;
   }
 }

--- a/mod/Jailbreak.Rebel/RebelManager.cs
+++ b/mod/Jailbreak.Rebel/RebelManager.cs
@@ -135,10 +135,7 @@ public class RebelManager(IRebelLocale notifs, IRichLogService logs)
     if (!player.IsReal() || player.Pawn.Value == null) return;
     var color = getRebelColor(player);
 
-    player.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
-    player.Pawn.Value.Render     = color;
-    Utilities.SetStateChanged(player.Pawn.Value, "CBaseModelEntity",
-      "m_clrRender");
+    player.SetColor(color);
 
     player.ColorScreen(
       Color.FromArgb(8 + (int)Math.Round(getRebelTimePercentage(player) * 32),

--- a/mod/Jailbreak.Rebel/RebelManager.cs
+++ b/mod/Jailbreak.Rebel/RebelManager.cs
@@ -125,8 +125,8 @@ public class RebelManager(IRebelLocale notifs, IRichLogService logs)
   private Color getRebelColor(CCSPlayerController player) {
     var percent             = getRebelTimePercentage(player);
     var percentRgb          = 255 - (int)Math.Round(percent * 255.0);
-    var color               = Color.FromArgb(254, 255, percentRgb, percentRgb);
-    if (percent <= 0) color = Color.FromArgb(254, 255, 255, 255);
+    var color               = Color.FromArgb(255, 255, percentRgb, percentRgb);
+    if (percent <= 0) color = Color.FromArgb(255, 255, 255, 255);
 
     return color;
   }

--- a/mod/Jailbreak.Rebel/RebelManager.cs
+++ b/mod/Jailbreak.Rebel/RebelManager.cs
@@ -126,7 +126,7 @@ public class RebelManager(IRebelLocale notifs, IRichLogService logs)
     var percent             = getRebelTimePercentage(player);
     var percentRgb          = 255 - (int)Math.Round(percent * 255.0);
     var color               = Color.FromArgb(255, 255, percentRgb, percentRgb);
-    if (percent <= 0) color = Color.FromArgb(255, 255, 255, 255);
+    if (percent <= 0) color = Color.White;
 
     return color;
   }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/HideAndSeekDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/HideAndSeekDay.cs
@@ -145,14 +145,15 @@ public class HideAndSeekDay(BasePlugin plugin, IServiceProvider provider)
     foreach (var ct in PlayerUtil.FromTeam(HiderTeam.Value)) ct.SetSpeed(1);
   }
 
-  override protected HookResult OnPickup(EventItemPickup @event,
-    GameEventInfo info) {
-    var lrProvider = provider.GetService<ILastRequestManager>();
-    if (lrProvider == null) return base.OnPickup(@event, info);
+  override protected void OnTick() {
+    var lr = Provider.GetService<ILastRequestManager>();
+    if (lr == null) {
+      base.OnTick();
+      return;
+    }
 
-    return lrProvider.IsLREnabled ?
-      HookResult.Continue :
-      base.OnPickup(@event, info);
+    if (lr.IsLREnabled) return;
+    base.OnTick();
   }
 
   public class HnsSettings : SpecialDaySettings {

--- a/mod/Jailbreak.SpecialDay/SpecialDays/NoScopeDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/NoScopeDay.cs
@@ -97,8 +97,9 @@ public class NoScopeDay(BasePlugin plugin, IServiceProvider provider)
       CtTeleport = TeleportType.RANDOM;
       TTeleport  = TeleportType.RANDOM;
 
-      ConVarValues["sv_gravity"]       = CV_GRAVITY.Value;
-      ConVarValues["sv_infinite_ammo"] = 2;
+      ConVarValues["sv_gravity"]        = CV_GRAVITY.Value;
+      ConVarValues["sv_infinite_ammo"]  = 2;
+      ConVarValues["mp_death_drop_gun"] = 0;
     }
 
     public override float FreezeTime(CCSPlayerController player) { return 1; }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/OneInTheChamberDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/OneInTheChamberDay.cs
@@ -33,6 +33,7 @@ public class OneInTheChamberDay(BasePlugin plugin, IServiceProvider provider)
 
   public override void Setup() {
     base.Setup();
+    Plugin.RegisterEventHandler<EventItemPickup>(OnPickup);
     Plugin.RegisterEventHandler<EventPlayerHurt>(OnPlayerDamage);
     Plugin.RegisterEventHandler<EventPlayerDeath>(OnPlayerDeath);
   }
@@ -53,9 +54,8 @@ public class OneInTheChamberDay(BasePlugin plugin, IServiceProvider provider)
     started = true;
   }
 
-  override protected HookResult OnPickup(EventItemPickup @event,
-    GameEventInfo info) {
-    if (!started) return base.OnPickup(@event, info);
+  protected HookResult OnPickup(EventItemPickup @event, GameEventInfo info) {
+    if (!started) return HookResult.Continue;
 
     var player = @event.Userid;
     if (player == null || !player.IsValid) return HookResult.Continue;

--- a/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
@@ -623,8 +623,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
     foreach (var player in PlayerUtil.GetAlive()) {
       if (player.Team == CsTeam.CounterTerrorist) ctMade = true;
       if (player.Team == CsTeam.Terrorist) tMade         = true;
-      if (finishedPlayers.Contains(player.Slot)) continue;
-      finishedPlayers.Add(player.Slot);
+      if (!finishedPlayers.Add(player.Slot)) continue;
 
       var dist = player.PlayerPawn.Value?.AbsOrigin?.Distance(target);
       if (dist == null) continue;
@@ -695,8 +694,6 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
 
       if (CV_WINNER_DAMAGEABLE.Value) EnableDamage(winner);
 
-      Plugin.DeregisterEventHandler<EventItemPickup>(OnPickup);
-
       foreach (var weapon in CV_LOSERS_WEAPONS.Value.Split(','))
         foreach (var loser in losers)
           loser.GiveNamedItem(weapon);
@@ -705,6 +702,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
         winner.GiveNamedItem(weapon);
 
       Plugin.RemoveListener<Listeners.OnTick>(checkFinishers);
+      Plugin.RemoveListener<Listeners.OnTick>(OnTick);
       RoundUtil.SetTimeRemaining(Math.Min(timeToSet, CV_WIN_TIME_MAX.Value));
       Server.ExecuteCommand("mp_ignore_round_win_conditions 0");
       return;
@@ -818,7 +816,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
     return result;
   }
 
-  public class SpeedrunSettings : SpecialDaySettings {
+  private class SpeedrunSettings : SpecialDaySettings {
     public SpeedrunSettings() {
       CtTeleport = TeleportType.RANDOM_STACKED;
       TTeleport = TeleportType.RANDOM_STACKED;

--- a/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
@@ -686,7 +686,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
       Msg.PlayerWon(winner).ToAllChat();
 
       foreach (var loser in losers) {
-        loser.SetColor(Color.FromArgb(254, Color.White));
+        loser.SetColor(Color.White);
         if (CV_TELEPORT_TYPE.Value == 1)
           loser.Teleport(winner);
         else if (CV_TELEPORT_TYPE.Value == 2) winner.Teleport(loser);
@@ -696,7 +696,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
       if (CV_WINNER_DAMAGEABLE.Value) EnableDamage(winner);
 
       Plugin.DeregisterEventHandler<EventItemPickup>(OnPickup);
-      
+
       foreach (var weapon in CV_LOSERS_WEAPONS.Value.Split(','))
         foreach (var loser in losers)
           loser.GiveNamedItem(weapon);

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -115,13 +115,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
 
     HasWarden = true;
     Warden    = controller;
-
-    if (Warden.Pawn.Value != null) {
-      Warden.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
-      Warden.Pawn.Value.Render     = Color.FromArgb(254, 0, 0, 255);
-      Utilities.SetStateChanged(Warden.Pawn.Value, "CBaseModelEntity",
-        "m_clrRender");
-    }
+    Warden.SetColor(Color.Blue);
 
     locale.NewWarden(Warden).ToAllChat().ToAllCenter();
 
@@ -204,11 +198,8 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     HasWarden = false;
 
     if (Warden != null && Warden.Pawn.Value != null) {
-      Warden.Clan                  = "";
-      Warden.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
-      Warden.Pawn.Value.Render     = Color.FromArgb(254, 255, 255, 255);
-      Utilities.SetStateChanged(Warden.Pawn.Value, "CBaseModelEntity",
-        "m_clrRender");
+      Warden.Clan = "";
+      Warden.SetColor(Color.White);
       Utilities.SetStateChanged(Warden, "CCSPlayerController", "m_szClan");
       var ev = new EventNextlevelChanged(true);
       ev.FireEvent(false);
@@ -310,12 +301,8 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
   private void unmarkPrisonersBlue() {
     foreach (var player in bluePrisoners) {
       if (!player.IsReal()) continue;
-      var pawn = player.Pawn.Value;
-      if (pawn == null) continue;
       if (ignoreColor(player)) continue;
-      pawn.RenderMode = RenderMode_t.kRenderNormal;
-      pawn.Render     = Color.FromArgb(254, 255, 255, 255);
-      Utilities.SetStateChanged(pawn, "CBaseModelEntity", "m_clrRender");
+      player.SetColor(Color.White);
     }
 
     bluePrisoners.Clear();
@@ -326,11 +313,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       if (!player.IsReal() || player.Team != CsTeam.Terrorist) continue;
       if (ignoreColor(player)) continue;
 
-      var pawn = player.Pawn.Value;
-      if (pawn == null) continue;
-      pawn.RenderMode = RenderMode_t.kRenderTransColor;
-      pawn.Render     = Color.FromArgb(254, 0, 0, 255);
-      Utilities.SetStateChanged(pawn, "CBaseModelEntity", "m_clrRender");
+      player.SetColor(Color.Blue);
 
       bluePrisoners.Add(player);
     }

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -418,8 +418,8 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       var cellZone = getCellZone();
 
       var prisoners = PlayerUtil.FromTeam(CsTeam.Terrorist)
-       .Count(p => p.Pawn.Value != null && p.Pawn.Value.AbsOrigin != null
-          && cellZone.IsInsideZone(p.Pawn.Value?.AbsOrigin!));
+       .Count(p => p.Pawn.Value != null && p.PlayerPawn.Value?.AbsOrigin != null
+          && cellZone.IsInsideZone(p.PlayerPawn.Value?.AbsOrigin!));
 
       if (openCmd.OpenedCells) {
         if (CV_WARDEN_AUTO_SNITCH.Value && prisoners > 0)
@@ -441,7 +441,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       if (prisoners == 0) return;
 
       if (CV_WARDEN_AUTO_SNITCH.Value) {
-        cmdLocale.CellsOpenedWithPrisoners(prisoners);
+        cmdLocale.CellsOpenedWithPrisoners(prisoners).ToAllChat();
       } else { cmdLocale.CellsOpened.ToAllChat(); }
     });
 

--- a/mod/Jailbreak.Warden/Jailbreak.Warden.csproj
+++ b/mod/Jailbreak.Warden/Jailbreak.Warden.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\public\Jailbreak.Formatting\Jailbreak.Formatting.csproj"/>
         <ProjectReference Include="..\..\public\Jailbreak.Public\Jailbreak.Public.csproj"/>
+        <ProjectReference Include="..\Jailbreak.Zones\Jailbreak.Zones.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/mod/Jailbreak.Warden/Selection/WardenSelectionBehavior.cs
+++ b/mod/Jailbreak.Warden/Selection/WardenSelectionBehavior.cs
@@ -111,6 +111,7 @@ public class
   ///   Timer callback that states it's time to choose the warden.
   /// </summary>
   protected void OnChooseWarden() {
+    guaranteedWarden.Clear();
     if (warden.HasWarden) return;
     var eligible = Utilities.GetPlayers()
      .Where(player => player.PawnIsAlive)

--- a/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
+++ b/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
@@ -58,10 +58,7 @@ public class SpecialTreatmentBehavior(IPlayerStateFactory factory,
       Color.FromArgb(255, 0, 255, 0) :
       Color.FromArgb(255, 255, 255, 255);
 
-    player.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
-    player.Pawn.Value.Render     = color;
-    Utilities.SetStateChanged(player.Pawn.Value, "CBaseModelEntity",
-      "m_clrRender");
+    player.SetColor(color);
   }
 
   private class SpecialTreatmentState {

--- a/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
+++ b/mod/Jailbreak.Warden/SpecialTreatment/SpecialTreatmentBehavior.cs
@@ -55,8 +55,8 @@ public class SpecialTreatmentBehavior(IPlayerStateFactory factory,
     if (!player.IsValid || player.Pawn.Value == null) return;
 
     var color = hasSt ?
-      Color.FromArgb(254, 0, 255, 0) :
-      Color.FromArgb(254, 255, 255, 255);
+      Color.FromArgb(255, 0, 255, 0) :
+      Color.FromArgb(255, 255, 255, 255);
 
     player.Pawn.Value.RenderMode = RenderMode_t.kRenderTransColor;
     player.Pawn.Value.Render     = color;

--- a/public/Jailbreak.Formatting/Views/Warden/IWardenCmdOpenLocale.cs
+++ b/public/Jailbreak.Formatting/Views/Warden/IWardenCmdOpenLocale.cs
@@ -20,5 +20,19 @@ public interface IWardenCmdOpenLocale {
   /// <returns></returns>
   public IView CellsOpenedBy(CCSPlayerController? player);
 
+  /// <summary>
+  /// Cells were opened with prisoners still inside.
+  /// </summary>
+  /// <param name="prisoners"></param>
+  /// <returns></returns>
+  public IView CellsOpenedWithPrisoners(int prisoners);
+
+  /// <summary>
+  /// Cells were already opened, but there are still prisoners inside.
+  /// </summary>
+  /// <param name="prisoners"></param>
+  /// <returns></returns>
+  public IView CellsOpenedSnitchPrisoners(int prisoners);
+
   public IView CannotOpenYet(int seconds);
 }

--- a/public/Jailbreak.Public/Extensions/StringExtensions.cs
+++ b/public/Jailbreak.Public/Extensions/StringExtensions.cs
@@ -8,4 +8,17 @@ public static class StringExtensions {
   public static bool IsVowel(this char c) {
     return "aeiouAEIOU".IndexOf(c) >= 0;
   }
+
+  // This is a comment => This Is A Comment
+  public static string ToTitleCase(this string unknown) {
+    var words = unknown.Split(' ');
+    for (var i = 0; i < words.Length; i++) {
+      if (words[i].Length == 0) continue;
+      var firstLetter = words[i][0];
+      words[i] = words[i][1..];
+      words[i] = firstLetter.ToString().ToUpper() + words[i].ToLower();
+    }
+
+    return string.Join(' ', words);
+  }
 }

--- a/public/Jailbreak.Public/Mod/SpecialDay/AbstractSpecialDay.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/AbstractSpecialDay.cs
@@ -50,7 +50,6 @@ public abstract class AbstractSpecialDay(BasePlugin plugin,
   public virtual void Setup() {
     Plugin.RegisterFakeConVars(this);
     Plugin.RegisterEventHandler<EventRoundEnd>(OnEnd);
-    Plugin.RegisterEventHandler<EventItemPickup>(OnPickup);
 
     foreach (var entry in Settings.ConVarValues) {
       var cv = ConVar.Find(entry.Key);
@@ -255,7 +254,11 @@ public abstract class AbstractSpecialDay(BasePlugin plugin,
   /// <summary>
   ///   Called when the actual action begins for the special day.
   /// </summary>
-  public virtual void Execute() { EnableDamage(); }
+  public virtual void Execute() {
+    EnableDamage();
+    if (Settings.RestrictWeapons)
+      Plugin.RegisterListener<Listeners.OnTick>(OnTick);
+  }
 
   virtual protected HookResult OnEnd(EventRoundEnd @event, GameEventInfo info) {
     foreach (var entry in previousConvarValues) {
@@ -264,26 +267,36 @@ public abstract class AbstractSpecialDay(BasePlugin plugin,
       SetConvarValue(cv, entry.Value);
     }
 
+    if (Settings.RestrictWeapons)
+      Plugin.RemoveListener<Listeners.OnTick>(OnTick);
+
     previousConvarValues.Clear();
 
     Plugin.DeregisterEventHandler<EventRoundEnd>(OnEnd);
-    Plugin.DeregisterEventHandler<EventItemPickup>(OnPickup);
     return HookResult.Continue;
   }
 
-  virtual protected HookResult OnPickup(EventItemPickup @event,
-    GameEventInfo info) {
-    var player = @event.Userid;
-    if (player == null || !player.IsValid) return HookResult.Continue;
-    var allowed = Settings.AllowedWeapons(player);
-    var weapon  = "weapon_" + @event.Item;
-    if (allowed == null || allowed.Contains(weapon)) return HookResult.Continue;
-    Server.NextFrame(() => { player.RemoveWeapons(); });
-    return HookResult.Continue;
+  virtual protected void OnTick() {
+    foreach (var player in PlayerUtil.GetAlive()) {
+      var weapons = Settings.AllowedWeapons(player);
+      if (weapons == null) continue;
+      disableWeapon(player, weapons);
+    }
   }
 
-  [Obsolete("No longer used, you must manually register/unregister this")]
-  virtual protected void OnTick() { }
+  private void disableWeapon(CCSPlayerController player,
+    ICollection<string> allowed) {
+    if (!player.IsReal()) return;
+    var pawn = player.PlayerPawn.Value;
+    if (pawn == null || !pawn.IsValid) return;
+    var weaponServices = pawn.WeaponServices;
+    if (weaponServices == null) return;
+    var activeWeapon = weaponServices.ActiveWeapon.Value;
+    if (activeWeapon == null || !activeWeapon.IsValid) return;
+    if (allowed.Contains(activeWeapon.DesignerName)) return;
+    activeWeapon.NextSecondaryAttackTick = Server.TickCount + 500;
+    activeWeapon.NextPrimaryAttackTick   = Server.TickCount + 500;
+  }
 
   protected void DisableDamage() {
     foreach (var player in PlayerUtil.GetAlive()) DisableDamage(player);

--- a/public/Jailbreak.Public/Mod/SpecialDay/SpecialDaySettings.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/SpecialDaySettings.cs
@@ -56,8 +56,6 @@ public class SpecialDaySettings {
   /// <summary>
   ///   Used to avoid registring a costly OnTick listener if false
   /// </summary>
-  [Obsolete(
-    "With the new optimization, we now remove weapons if disallowed, making this obsolete.")]
   public bool RestrictWeapons = false;
 
   /// <summary>


### PR DESCRIPTION
- **[Issue JB-106](https://bug.msws.xyz/issue/JB-106)**: Fixes the issue where the Guaranteed Warden persists across multiple rounds instead of resetting.
- **[Issue JB-88](https://bug.msws.xyz/issue/JB-88)**: Reverts the weapon restriction system to its previous state.
- **[Issue JB-54](https://bug.msws.xyz/issue/JB-54)**: Enhances the logic to detect if cells have already been opened and prevents auto-opening if a significant percentage of prisoners are already out.
- **[Issue JB-91](https://bug.msws.xyz/issue/JB-91)**: Adds a feature to snitch on who is still in cells when they auto-open.
- **[Issue JB-90](https://bug.msws.xyz/issue/JB-90)**: Increases the number of in-game ads, covering features like RTD, legs, soccer, and chicken.
- **[Issue EDG-38](https://bug.msws.xyz/issue/EDG-38)**: Updates the [DS] Chat prefix to [DS Chat].