### PR TITLE
Fix Synchronicity, Improve Messaging, and Balance Credit Rewards in Jailbreak Modules 

### DIFF
--- a/lang/Jailbreak.English/SpecialDay/SpeedrunDayLocale.cs
+++ b/lang/Jailbreak.English/SpecialDay/SpeedrunDayLocale.cs
@@ -39,7 +39,7 @@ public class SpeedrunDayLocale() : SoloDayLocale("Speedrunners",
       return new SimpleView {
         {
           PREFIX,
-          $"Round {ChatColors.Yellow}#{round}{ChatColors.Default} begins! The slowest",
+          $"Round{ChatColors.Yellow}#{round}{ChatColors.Grey} begins! The slowest",
           "player to reach the goal will be eliminated!"
         },
         SimpleView.NEWLINE,
@@ -49,7 +49,7 @@ public class SpeedrunDayLocale() : SoloDayLocale("Speedrunners",
     return new SimpleView {
       {
         PREFIX,
-        $"Round {ChatColors.Yellow}#{round}{ChatColors.Default} begins! The slowest",
+        $"Round {ChatColors.Yellow}#{round}{ChatColors.Grey} begins! The slowest",
         eliminationCount, "players to reach the goal will be eliminated!"
       },
       SimpleView.NEWLINE,

--- a/mod/Jailbreak.LastRequest/LastRequestManager.cs
+++ b/mod/Jailbreak.LastRequest/LastRequestManager.cs
@@ -158,7 +158,8 @@ public class LastRequestManager(ILRLocale messages, IServiceProvider provider)
      .ToList();
     Task.Run(async () => {
       foreach (var survivor in survivors) {
-        await eco.Grant(survivor, 100, reason: "LR Reached");
+        await eco.Grant(survivor, survivor.Team == CsTeam.Terrorist ? 75 : 50,
+          reason: "LR Reached");
         await incrementLRReached(survivor);
       }
     });

--- a/mod/Jailbreak.RTD/Rewards/CreditReward.cs
+++ b/mod/Jailbreak.RTD/Rewards/CreditReward.cs
@@ -19,36 +19,17 @@ public class CreditReward(int credits, IRTDLocale locale) : IRTDReward {
 
   public bool Enabled => API.Gangs != null;
 
-  private static readonly Queue<(PlayerWrapper, int)> rewards = new();
-
   public bool PrepareReward(CCSPlayerController player) {
     var eco = API.Gangs?.Services.GetService<IEcoManager>();
     if (eco == null) return false;
     var wrapper = new PlayerWrapper(player);
 
-    rewards.Enqueue((wrapper, credits));
-
-    Task.Run(async () => await processQueue());
 
     if (Math.Abs(credits) >= 5000)
       locale.JackpotReward(player, credits).ToAllChat();
 
+    Task.Run(async () => await eco.Grant(wrapper, credits, true, "RTD"));
     return true;
-  }
-
-  private async Task processQueue() {
-    while (true) {
-      var eco = API.Gangs?.Services.GetService<IEcoManager>();
-      if (eco == null) {
-        rewards.Clear();
-        return;
-      }
-
-      if (rewards.Count == 0) return;
-      var (player, amount) = rewards.Dequeue();
-
-      await eco.Grant(player, amount, true, "RTD");
-    }
   }
 
   public bool GrantReward(CCSPlayerController player) { return true; }

--- a/mod/Jailbreak.Rebel/RebelListener.cs
+++ b/mod/Jailbreak.Rebel/RebelListener.cs
@@ -39,11 +39,15 @@ public class RebelListener(IRebelService rebelService,
     if (player.Team != CsTeam.Terrorist) return HookResult.Continue;
     if (!rebelService.IsRebel(player)) return HookResult.Continue;
 
-    var eco = API.Gangs?.Services.GetService<IEcoManager>();
+    var attacker = ev.Attacker;
 
+    if (attacker == null || !attacker.IsValid || attacker.IsBot)
+      return HookResult.Continue;
+
+    var eco = API.Gangs?.Services.GetService<IEcoManager>();
     if (eco == null) return HookResult.Continue;
 
-    var wrapper = new PlayerWrapper(player);
+    var wrapper = new PlayerWrapper(attacker);
     var hasGun  = playerHasGun(player);
 
     Task.Run(async ()

--- a/mod/Jailbreak.Rebel/RebelListener.cs
+++ b/mod/Jailbreak.Rebel/RebelListener.cs
@@ -1,10 +1,14 @@
 ﻿using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Utils;
+using GangsAPI.Data;
+using GangsAPI.Services;
+using Jailbreak.Public;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
 using Jailbreak.Public.Mod.LastRequest;
 using Jailbreak.Public.Mod.Rebel;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Jailbreak.Rebel;
 
@@ -25,5 +29,37 @@ public class RebelListener(IRebelService rebelService,
 
     rebelService.MarkRebel(attacker);
     return HookResult.Continue;
+  }
+
+  [GameEventHandler]
+  public HookResult OnDeath(EventPlayerDeath ev, GameEventInfo info) {
+    var player = ev.Userid;
+    if (player == null || !player.IsValid || player.IsBot)
+      return HookResult.Continue;
+    if (player.Team != CsTeam.Terrorist) return HookResult.Continue;
+    if (!rebelService.IsRebel(player)) return HookResult.Continue;
+
+    var eco = API.Gangs?.Services.GetService<IEcoManager>();
+
+    if (eco == null) return HookResult.Continue;
+
+    var wrapper = new PlayerWrapper(player);
+    var hasGun  = playerHasGun(player);
+
+    Task.Run(async ()
+      => await eco.Grant(wrapper, hasGun ? 20 : 10, true, "Rebel Kill"));
+    return HookResult.Continue;
+  }
+
+  private bool playerHasGun(CCSPlayerController player) {
+    var weapons = player.Pawn.Value?.WeaponServices;
+    if (weapons == null) return false;
+    foreach (var weapon in weapons.MyWeapons) {
+      if (weapon.Value == null) continue;
+      if (!Tag.GUNS.Contains(weapon.Value.DesignerName)) continue;
+      return true;
+    }
+
+    return false;
   }
 }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/NoScopeDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/NoScopeDay.cs
@@ -14,7 +14,7 @@ using Jailbreak.Validator;
 namespace Jailbreak.SpecialDay.SpecialDays;
 
 public class NoScopeDay(BasePlugin plugin, IServiceProvider provider)
-  : AbstractSpecialDay(plugin, provider) {
+  : AbstractSpecialDay(plugin, provider), ISpecialDayMessageProvider {
   public static readonly FakeConVar<string> CV_WEAPON = new(
     "jb_sd_noscope_weapon",
     "Weapon to give to all players, recommended it be a weapon with a scope (duh)",

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Text.Json;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
@@ -149,7 +150,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       Server.NextFrameAsync(async () => {
         oldTag      = await API.Actain.getTagService().GetTag(steam);
         oldTagColor = await API.Actain.getTagService().GetTagColor(steam);
-        Server.NextFrame(() => {
+        await Server.NextFrameAsync(() => {
           if (!Warden.IsValid) return;
           API.Actain.getTagService().SetTag(Warden, "[WARDEN]", false);
           API.Actain.getTagService()
@@ -299,19 +300,25 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     if (player == null || !player.IsValid) return HookResult.Continue;
     var isWarden = ((IWardenService)this).IsWarden(player);
     if (API.Gangs != null) {
+      PlayerWrapper? wardenWrapper = null;
       if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player
-        && isWarden) {
-        var wrapper = new PlayerWrapper(ev.Attacker);
-        Task.Run(async () => await incrementWardenKills(wrapper));
-      }
+        && isWarden)
+        wardenWrapper = new PlayerWrapper(ev.Attacker);
 
-      foreach (var guard in PlayerUtil.FromTeam(CsTeam.CounterTerrorist)) {
-        var wrapper = new PlayerWrapper(guard);
-        // If the guard is the warden, update all guards' stats
-        // If the guard is not the warden, only update the warden's stats
-        if (guard.SteamID == player.SteamID == isWarden) continue;
-        Task.Run(async () => await updateGuardDeathStats(wrapper, isWarden));
-      }
+      var wardenSteam = player.SteamID;
+      var toDecrement = PlayerUtil.FromTeam(CsTeam.CounterTerrorist)
+       .Where(p => p.IsReal() && !p.IsBot)
+       .Select(p => new PlayerWrapper(p));
+      Task.Run(async () => {
+        if (wardenWrapper != null) await incrementWardenKills(wardenWrapper);
+        foreach (var guard in toDecrement) {
+          // var wrapper = new PlayerWrapper(guard);
+          // If the guard is the warden, update all guards' stats
+          // If the guard is not the warden, only update the warden's stats
+          if (guard.Steam == wardenSteam == isWarden) continue;
+          await updateGuardDeathStats(guard, isWarden);
+        }
+      });
     }
 
     if (!isWarden) return HookResult.Continue;
@@ -319,6 +326,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     API.Stats?.PushStat(new ServerStat("JB_WARDEN_DEATH"));
 
     mute.UnPeaceMute();
+
     processWardenDeath();
     return HookResult.Continue;
   }

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -301,7 +301,6 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     if (player.Team != CsTeam.CounterTerrorist) return HookResult.Continue;
     var isWarden = ((IWardenService)this).IsWarden(player);
     if (API.Gangs != null) {
-      var            eco = API.Gangs.Services.GetService<IEcoManager>();
       PlayerWrapper? attackerWrapper = null;
       if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player
         && isWarden)
@@ -311,6 +310,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       var toDecrement = PlayerUtil.FromTeam(CsTeam.CounterTerrorist)
        .Where(p => p.IsReal() && !p.IsBot)
        .Select(p => new PlayerWrapper(p));
+      var eco = API.Gangs.Services.GetService<IEcoManager>();
       Task.Run(async () => {
         if (attackerWrapper != null) {
           await incrementWardenKills(attackerWrapper);

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -336,7 +336,6 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     API.Stats?.PushStat(new ServerStat("JB_WARDEN_DEATH"));
 
     mute.UnPeaceMute();
-
     processWardenDeath();
     return HookResult.Continue;
   }

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -302,8 +302,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     var isWarden = ((IWardenService)this).IsWarden(player);
     if (API.Gangs != null) {
       PlayerWrapper? attackerWrapper = null;
-      if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player
-        && isWarden)
+      if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player)
         attackerWrapper = new PlayerWrapper(ev.Attacker);
 
       var wardenSteam = player.SteamID;
@@ -313,7 +312,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       var eco = API.Gangs.Services.GetService<IEcoManager>();
       Task.Run(async () => {
         if (attackerWrapper != null) {
-          await incrementWardenKills(attackerWrapper);
+          if (isWarden) await incrementWardenKills(attackerWrapper);
           if (eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
             var giveAmo    = isWarden ? 25 : 10;

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -315,7 +315,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
           if (isWarden) await incrementWardenKills(attackerWrapper);
           if (eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
-            var giveAmo    = isWarden ? 25 : 10;
+            var giveAmo    = isWarden ? 50 : 20;
             await eco.Grant(attackerWrapper, giveAmo, true, giveReason);
           }
         }


### PR DESCRIPTION
1. **NoScopeDay**:  
   - Added `ISpecialDayMessageProvider` to ensure titles are properly displayed.  

2. **SpeedrunDay**:  
   - Corrected color formatting in round announcements for better clarity.  

3. **RTD Credit Rewards**:  
   - Implemented a queue system for synchronous credit processing.  

4. **Last Guard**:  
   - Fixed asynchronous stat updates for Last Guard participants.  

5. **Warden Behavior**:  
   - Resolved gang stat updates and ensured proper stat decrementing for guards.  

6. **Last Request**:  
   - Reduced credit rewards for Last Request survivors based on their team.  

7. **Rebel Kills**:  
   - Added credit rewards for rebels based on their loadout during kills.  