### PR TITLE
Enhance Credit System, Async Calls, and Gameplay Mechanics in Jailbreak Mod

### DIFF
--- a/mod/Jailbreak.LastGuard/LastGuard.cs
+++ b/mod/Jailbreak.LastGuard/LastGuard.cs
@@ -82,7 +82,8 @@ public class LastGuard(ILGLocale notifications, ILastRequestManager lrManager,
     if (gangStats != null) {
       var players = PlayerUtil.GetAlive()
        .Where(p => p.IsReal() && !p.IsBot)
-       .Select(p => new PlayerWrapper(p));
+       .Select(p => new PlayerWrapper(p))
+       .ToList();
       Task.Run(async () => {
         foreach (var wrapper in players) {
           var (success, stat) =

--- a/mod/Jailbreak.LastRequest/LastRequestManager.cs
+++ b/mod/Jailbreak.LastRequest/LastRequestManager.cs
@@ -269,7 +269,7 @@ public class LastRequestManager(ILRLocale messages, IServiceProvider provider)
     return data;
   }
 
-  private static bool shouldGrantCredits() {
+  public static bool shouldGrantCredits() {
     if (API.Gangs == null) return false;
     return Utilities.GetPlayers().Count >= CV_MIN_PLAYERS_FOR_CREDITS.Value;
   }

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -92,7 +92,7 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
       var value  = await cookie.Get(steam);
       var enable = value is not (null or "Y");
       await cookie.Set(steam, enable ? "Y" : "N");
-      Server.NextFrame(() => {
+      await Server.NextFrameAsync(() => {
         if (!executor.IsValid) return;
         locale.AutoRTDToggled(enable).ToChat(executor);
         cachedCookies[steam] = enable;

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -37,6 +37,8 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
   public HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info) {
     if (RoundUtil.IsWarmup()) return HookResult.Continue;
 
+    if (cookie == null) return HookResult.Continue;
+
     Server.NextFrame(() => {
       foreach (var player in Utilities.GetPlayers()
        .Where(player
@@ -44,20 +46,7 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
        .Where(player => !rewarder.HasReward(player))) {
         var steam = player.SteamID;
         if (!cachedCookies.ContainsKey(steam)) {
-          if (cookie != null) {
-            Server.NextFrameAsync(async () => {
-              var val = await cookie.Get(steam);
-              cachedCookies[steam] = val is null or "Y";
-              if (cachedCookies[steam])
-                Server.NextFrame(() => {
-                  if (!player.IsValid) return;
-                  player.ExecuteClientCommandFromServer("css_rtd");
-                });
-            });
-            continue;
-          }
-
-          cachedCookies[steam] = true;
+          Server.NextFrameAsync(async () => await populateCache(player, steam));
         }
 
         if (cachedCookies.TryGetValue(player.SteamID, out var value) && value)
@@ -66,6 +55,17 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
     });
 
     return HookResult.Continue;
+  }
+
+  private async Task populateCache(CCSPlayerController player, ulong steam) {
+    if (cookie == null) return;
+    var val = await cookie.Get(steam);
+    cachedCookies[steam] = val is null or "Y";
+    if (!cachedCookies[steam]) return;
+    await Server.NextFrameAsync(() => {
+      if (!player.IsValid) return;
+      player.ExecuteClientCommandFromServer("css_rtd");
+    });
   }
 
   [ConsoleCommand("css_autortd")]

--- a/mod/Jailbreak.RTD/Rewards/CreditReward.cs
+++ b/mod/Jailbreak.RTD/Rewards/CreditReward.cs
@@ -24,7 +24,6 @@ public class CreditReward(int credits, IRTDLocale locale) : IRTDReward {
     if (eco == null) return false;
     var wrapper = new PlayerWrapper(player);
 
-
     if (Math.Abs(credits) >= 5000)
       locale.JackpotReward(player, credits).ToAllChat();
 

--- a/mod/Jailbreak.Rebel/Jailbreak.Rebel.csproj
+++ b/mod/Jailbreak.Rebel/Jailbreak.Rebel.csproj
@@ -10,6 +10,7 @@
         <ProjectReference Include="..\..\public\Jailbreak.Formatting\Jailbreak.Formatting.csproj"/>
         <ProjectReference Include="..\..\public\Jailbreak.Public\Jailbreak.Public.csproj"/>
         <ProjectReference Include="..\Gangs.BombIconPerk\Gangs.BombIconPerk.csproj"/>
+        <ProjectReference Include="..\Jailbreak.LastRequest\Jailbreak.LastRequest.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/mod/Jailbreak.Rebel/RebelListener.cs
+++ b/mod/Jailbreak.Rebel/RebelListener.cs
@@ -4,6 +4,7 @@ using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Utils;
 using GangsAPI.Data;
 using GangsAPI.Services;
+using Jailbreak.LastRequest;
 using Jailbreak.Public;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
@@ -31,13 +32,13 @@ public class RebelListener(IRebelService rebelService,
 
     var weapon = "weapon_" + @event.Weapon;
     if (Tag.SNIPERS.Contains(weapon) && weapon != "weapon_ssg08")
-      weaponScores[player.Slot] = 25;
+      weaponScores[attacker.Slot] = 25;
     else if (Tag.RIFLES.Contains(weapon))
-      weaponScores[player.Slot] = 20;
+      weaponScores[attacker.Slot] = 20;
     else if (Tag.GUNS.Contains(weapon))
-      weaponScores[player.Slot] = 15;
+      weaponScores[attacker.Slot] = 15;
     else
-      weaponScores[player.Slot] = 10;
+      weaponScores[attacker.Slot] = 10;
 
     rebelService.MarkRebel(attacker);
     return HookResult.Continue;
@@ -56,9 +57,9 @@ public class RebelListener(IRebelService rebelService,
       return HookResult.Continue;
     if (player.Team != CsTeam.Terrorist) return HookResult.Continue;
     if (!rebelService.IsRebel(player)) return HookResult.Continue;
+    if (LastRequestManager.shouldGrantCredits()) return HookResult.Continue;
 
     var attacker = ev.Attacker;
-
     if (attacker == null || !attacker.IsValid || attacker.IsBot)
       return HookResult.Continue;
 

--- a/mod/Jailbreak.Rebel/RebelListener.cs
+++ b/mod/Jailbreak.Rebel/RebelListener.cs
@@ -39,11 +39,15 @@ public class RebelListener(IRebelService rebelService,
     if (player.Team != CsTeam.Terrorist) return HookResult.Continue;
     if (!rebelService.IsRebel(player)) return HookResult.Continue;
 
-    var eco = API.Gangs?.Services.GetService<IEcoManager>();
+    var attacker = ev.Attacker;
 
+    if (attacker == null || !attacker.IsValid || attacker.IsBot)
+      return HookResult.Continue;
+
+    var eco = API.Gangs?.Services.GetService<IEcoManager>();
     if (eco == null) return HookResult.Continue;
 
-    var wrapper = new PlayerWrapper(player);
+    var wrapper = new PlayerWrapper(attacker);
     var hasGun  = playerHasGun(player);
 
     Task.Run(async ()

--- a/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
@@ -12,16 +12,17 @@ public class SpecialDayFactory(IServiceProvider provider) : ISpecialDayFactory {
 
   public AbstractSpecialDay CreateSpecialDay(SDType type) {
     return type switch {
-      SDType.FFA       => new FFADay(plugin, provider),
-      SDType.WARDAY    => new WardayDay(plugin, provider),
-      SDType.HNS       => new HideAndSeekDay(plugin, provider),
-      SDType.NOSCOPE   => new NoScopeDay(plugin, provider),
-      SDType.INFECTION => new InfectionDay(plugin, provider),
+      SDType.BHOP      => new BHopDay(plugin, provider),
       SDType.CUSTOM    => new CustomDay(plugin, provider),
-      SDType.SPEEDRUN  => new SpeedrunDay(plugin, provider),
-      SDType.OITC      => new OneInTheChamberDay(plugin, provider),
-      SDType.TELEPORT  => new TeleportDay(plugin, provider),
+      SDType.FFA       => new FFADay(plugin, provider),
       SDType.GUNGAME   => new GunGameDay(plugin, provider),
+      SDType.HNS       => new HideAndSeekDay(plugin, provider),
+      SDType.INFECTION => new InfectionDay(plugin, provider),
+      SDType.NOSCOPE   => new NoScopeDay(plugin, provider),
+      SDType.OITC      => new OneInTheChamberDay(plugin, provider),
+      SDType.SPEEDRUN  => new SpeedrunDay(plugin, provider),
+      SDType.TELEPORT  => new TeleportDay(plugin, provider),
+      SDType.WARDAY    => new WardayDay(plugin, provider),
       _                => throw new NotImplementedException()
     };
   }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/BHopDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/BHopDay.cs
@@ -1,0 +1,35 @@
+﻿using CounterStrikeSharp.API.Core;
+using Jailbreak.English.SpecialDay;
+using Jailbreak.Formatting.Views.SpecialDay;
+using Jailbreak.Public.Mod.SpecialDay;
+using Jailbreak.Public.Mod.SpecialDay.Enums;
+
+namespace Jailbreak.SpecialDay.SpecialDays;
+
+public class BHopDay(BasePlugin plugin, IServiceProvider provider)
+  : AbstractSpecialDay(plugin, provider), ISpecialDayMessageProvider {
+  public override SDType Type => SDType.CUSTOM;
+
+  public override SpecialDaySettings Settings => new BHopSettings();
+
+  public ISDInstanceLocale Locale
+    => new TeamDayLocale("Bunny Hop Day",
+      "Auto-Bunny hopping is on, otherwise normal day!");
+
+  public override void Setup() {
+    Timers[3] += Execute;
+    base.Setup();
+  }
+
+  public class BHopSettings : SpecialDaySettings {
+    public BHopSettings() {
+      StripToKnife      = false;
+      AllowLastRequests = true;
+      AllowRebels       = true;
+      OpenCells         = false;
+
+      ConVarValues["sv_enablebunnyhopping"] = true;
+      ConVarValues["sv_autobunnyhopping"]   = true;
+    }
+  }
+}

--- a/mod/Jailbreak.SpecialDay/SpecialDays/GunGameDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/GunGameDay.cs
@@ -200,14 +200,11 @@ public class GunGameDay(BasePlugin plugin, IServiceProvider provider)
     var weapon  = weaponProgression[progress];
     var allowed = new HashSet<string> { weapon, "weapon_knife" };
 
-    if (allowed.Contains("weapon_mp5sd")) allowed.Add("weapon_mp7");
-    if (allowed.Contains("weapon_mp7")) allowed.Add("weapon_mp5sd");
-    if (allowed.Contains("weapon_m4a1_silencer")) allowed.Add("weapon_m4a1");
-    if (allowed.Contains("weapon_m4a1")) allowed.Add("weapon_m4a1_silencer");
-    if (allowed.Contains("weapon_usp_silencer")) allowed.Add("weapon_hkp2000");
-    if (allowed.Contains("weapon_hkp2000")) allowed.Add("weapon_usp_silencer");
-    if (allowed.Contains("weapon_deagle")) allowed.Add("weapon_revolver");
-    if (allowed.Contains("weapon_revolver")) allowed.Add("weapon_deagle");
+    if (Tag.RIFLES.Contains(weapon))
+      allowed = allowed.Union(Tag.RIFLES).ToHashSet();
+
+    if (Tag.PISTOLS.Contains(weapon))
+      allowed = allowed.Union(Tag.PISTOLS).ToHashSet();
 
     return allowed.Union(Tag.UTILITY).ToHashSet();
   }

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -336,7 +336,6 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     API.Stats?.PushStat(new ServerStat("JB_WARDEN_DEATH"));
 
     mute.UnPeaceMute();
-
     processWardenDeath();
     return HookResult.Continue;
   }

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -302,8 +302,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     var isWarden = ((IWardenService)this).IsWarden(player);
     if (API.Gangs != null) {
       PlayerWrapper? attackerWrapper = null;
-      if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player
-        && isWarden)
+      if (ev.Attacker != null && ev.Attacker.IsValid && ev.Attacker != player)
         attackerWrapper = new PlayerWrapper(ev.Attacker);
 
       var wardenSteam = player.SteamID;
@@ -313,7 +312,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       var eco = API.Gangs.Services.GetService<IEcoManager>();
       Task.Run(async () => {
         if (attackerWrapper != null) {
-          await incrementWardenKills(attackerWrapper);
+          if (isWarden) await incrementWardenKills(attackerWrapper);
           if (eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
             var giveAmo    = isWarden ? 25 : 10;

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -313,11 +313,12 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       var toDecrement = PlayerUtil.FromTeam(CsTeam.CounterTerrorist)
        .Where(p => p.IsReal() && !p.IsBot)
        .Select(p => new PlayerWrapper(p));
-      var eco = API.Gangs.Services.GetService<IEcoManager>();
+      var eco                = API.Gangs.Services.GetService<IEcoManager>();
+      var shouldGrantCredits = LastRequestManager.shouldGrantCredits();
       Task.Run(async () => {
         if (attackerWrapper != null) {
           if (isWarden) await incrementWardenKills(attackerWrapper);
-          if (LastRequestManager.shouldGrantCredits() && eco != null) {
+          if (shouldGrantCredits && eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
             var giveAmo    = isWarden ? 50 : 20;
             await eco.Grant(attackerWrapper, giveAmo, true, giveReason);
@@ -325,7 +326,6 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
         }
 
         foreach (var guard in toDecrement) {
-          // var wrapper = new PlayerWrapper(guard);
           // If the guard is the warden, update all guards' stats
           // If the guard is not the warden, only update the warden's stats
           if (guard.Steam == wardenSteam == isWarden) continue;

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -13,6 +13,7 @@ using GangsAPI.Services.Player;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views.Logging;
 using Jailbreak.Formatting.Views.Warden;
+using Jailbreak.LastRequest;
 using Jailbreak.Public;
 using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Extensions;
@@ -313,7 +314,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
       Task.Run(async () => {
         if (attackerWrapper != null) {
           if (isWarden) await incrementWardenKills(attackerWrapper);
-          if (eco != null) {
+          if (LastRequestManager.shouldGrantCredits() && eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
             var giveAmo    = isWarden ? 50 : 20;
             await eco.Grant(attackerWrapper, giveAmo, true, giveReason);
@@ -353,8 +354,8 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
     });
   }
 
-  private async Task
-    updateGuardDeathStats(PlayerWrapper player, bool isWarden) {
+  private async Task updateGuardDeathStats(PlayerWrapper player,
+    bool isWarden) {
     var stats = API.Gangs?.Services.GetService<IPlayerStatManager>();
     if (stats == null) return;
 

--- a/mod/Jailbreak.Warden/Global/WardenBehavior.cs
+++ b/mod/Jailbreak.Warden/Global/WardenBehavior.cs
@@ -315,7 +315,7 @@ public class WardenBehavior(ILogger<WardenBehavior> logger,
           if (isWarden) await incrementWardenKills(attackerWrapper);
           if (eco != null) {
             var giveReason = (isWarden ? "Warden" : "Guard") + " Kill";
-            var giveAmo    = isWarden ? 25 : 10;
+            var giveAmo    = isWarden ? 50 : 20;
             await eco.Grant(attackerWrapper, giveAmo, true, giveReason);
           }
         }

--- a/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
@@ -2,6 +2,7 @@ namespace Jailbreak.Public.Mod.SpecialDay.Enums;
 
 public enum SDType {
   CUSTOM,
+  BHOP,
   FFA,
   GUNGAME,
   GHOST,


### PR DESCRIPTION
### Patch 1: **Player Requirements for Credit Income**
- **Changes:**
  - Made `shouldGrantCredits` public for use across modules.
  - Ensured credit rewards only grant if minimum player requirements are met.
  - Corrected some logic for weapon score handling in `RebelListener.cs`.
  - Updated references in `.csproj` files to include necessary dependencies.

### Patch 2: **Switch AutoRTD to Use `NextFrameAsync`**
- **Changes:**
  - Replaced synchronous `NextFrame` calls with asynchronous `NextFrameAsync` for better performance and handling of delayed execution.

### Patch 3: **Fix Wrong Armor Assignment**
- **Changes:**
  - Adjusted logic in `WardenBehavior.cs` to assign the correct armor value when a conflict arises between default and player-specific armor values.

### Patch 4: **Fix Wrong Variable Name**
- **Changes:**
  - Corrected a variable name in `WardenBehavior.cs` to ensure proper logic handling for armor assignment.

### Patch 5: **Handle Async Call Issues**
- **Changes:**
  - Added error handling for potential issues in asynchronous operations, particularly in `AutoRTD` and `LastGuard` modules.
  - Introduced a helper method (`populateCache`) to streamline async caching logic.

### Patch 6: **Disable Credit Granting During Special Days**
- **Changes:**
  - Added checks in `WardenBehavior.cs` to prevent credit granting during "Special Days" to align with game balance.