### PR TITLE
Add message indicating command stays on pass

### DIFF
--- a/lang/Jailbreak.English/Warden/WardenLocale.cs
+++ b/lang/Jailbreak.English/Warden/WardenLocale.cs
@@ -16,6 +16,9 @@ public class WardenLocale : IWardenLocale,
       Plain = false, Panorama = false, Chat = true
     };
 
+  public static readonly FormatObject COMMAND_STANDS =
+    new HiddenFormatObject($"The previous command stands for 10 seconds.");
+
   public IView PickingShortly
     => new SimpleView {
       PREFIX,
@@ -27,9 +30,15 @@ public class WardenLocale : IWardenLocale,
       PREFIX,
       $"No one in queue. Next guard to {ChatColors.BlueGrey}!warden{ChatColors.Grey} will become warden."
     };
+  
+  public IView NowFreeday
+    => new SimpleView {
+      PREFIX,
+      $"It is now a freeday! CTs must pursue {ChatColors.BlueGrey}!warden{ChatColors.Grey}."
+    };
 
   public IView WardenLeft
-    => new SimpleView { PREFIX, "The warden left the game." };
+    => new SimpleView { PREFIX, "The warden left the game.", COMMAND_STANDS };
 
   public IView WardenDied
     => new SimpleView {
@@ -41,12 +50,6 @@ public class WardenLocale : IWardenLocale,
         PREFIX,
         $"CTs must pursue {ChatColors.BlueGrey}!warden{ChatColors.Grey}."
       }
-    };
-
-  public IView PassCommandStays
-    => new SimpleView {
-      PREFIX,
-      "Previous orders remain until new orders are given. It will become a freeday in 10 seconds."
     };
 
   public IView BecomeNextWarden
@@ -77,11 +80,11 @@ public class WardenLocale : IWardenLocale,
     };
 
   public IView PassWarden(CCSPlayerController player) {
-    return new SimpleView { PREFIX, player, "resigned from warden." };
+    return new SimpleView { PREFIX, player, "resigned from warden.", COMMAND_STANDS };
   }
 
   public IView FireWarden(CCSPlayerController player) {
-    return new SimpleView { PREFIX, player, "was fired from warden." };
+    return new SimpleView { PREFIX, player, "was fired from warden.", COMMAND_STANDS };
   }
 
   public IView
@@ -91,7 +94,8 @@ public class WardenLocale : IWardenLocale,
       admin,
       "fired",
       player,
-      "from warden."
+      "from warden.",
+      COMMAND_STANDS
     };
   }
 

--- a/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/WardenCommandsBehavior.cs
@@ -42,7 +42,6 @@ public class WardenCommandsBehavior(IWardenLocale locale,
       clients.ExecuteClientCommand(
         $"play sounds/{WardenBehavior.CV_WARDEN_SOUND_PASSED.Value}");
 
-    locale.PassCommandStays.ToAllChat();
     locale.BecomeNextWarden.ToAllChat();
 
     if (!warden.TryRemoveWarden(true))
@@ -76,7 +75,6 @@ public class WardenCommandsBehavior(IWardenLocale locale,
         $"play sounds/{WardenBehavior.CV_WARDEN_SOUND_PASSED.Value}");
     }
 
-    locale.PassCommandStays.ToAllChat();
     locale.BecomeNextWarden.ToAllChat();
 
     lastPassCommand[warden.Warden] = DateTime.Now;

--- a/public/Jailbreak.Formatting/Views/Warden/IWardenLocale.cs
+++ b/public/Jailbreak.Formatting/Views/Warden/IWardenLocale.cs
@@ -8,9 +8,9 @@ namespace Jailbreak.Formatting.Views.Warden;
 public interface IWardenLocale {
   public IView PickingShortly { get; }
   public IView NoWardens { get; }
+  public IView NowFreeday { get; }
   public IView WardenLeft { get; }
   public IView WardenDied { get; }
-  public IView PassCommandStays { get; }
   public IView BecomeNextWarden { get; }
   public IView JoinRaffle { get; }
   public IView LeaveRaffle { get; }


### PR DESCRIPTION
To prevent confusion among Ts, this PR returns the message on pass/fire indicating that the command stays and when it becomes a freeday.

~~This PR does *not* implement a timer of any form to actually declare it a freeday after those 10s, though that *may* be desirable behaviour? (I can't remember whether this was the case in GO). If so, let me know.~~