### PR TITLE
Null Cookie Retry

### DIFF
--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -73,22 +73,21 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
   public void Command_AutoRTD(CCSPlayerController? executor, CommandInfo info) {
     if (executor == null) return;
 
-    // if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
-    //   rtdLocale.RollingDisabled().ToChat(executor);
-    //   return;
-    // }
+    if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
+      rtdLocale.RollingDisabled().ToChat(executor);
+      return;
+    }
 
+    rtdLocale.DebugPrintMessage($"You are bypassing permission checks. Do NOT let this go into release. Remove the commented lines.").ToChat(executor);
     // if (!AdminManager.PlayerHasPermissions(executor, CV_AUTORTD_FLAG.Value)) {
     //   generic.NoPermissionMessage(CV_AUTORTD_FLAG.Value).ToChat(executor);
     //   return;
     // }
 
-    // if (cookie == null) {
-    //   locale.TogglingNotEnabled.ToChat(executor);
-    //   return;
-    // }
-    
-    rtdLocale.DebugPrintMessage($"You are bypassing important checks. Do NOT let this go into release. Remove the commented lines.").ToChat(executor);
+    if (cookie == null) {
+      locale.TogglingNotEnabled.ToChat(executor);
+      return;
+    }
 
     var steam = executor.SteamID;
     Task.Run(async () => {
@@ -104,7 +103,11 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
       var enable = value is not (null or "Y");
       
       // Debugging enable value
-      rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
+      if (enable != null) {
+        rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
+      } else {
+        rtdLocale.DebugPrintMessage($"Enable was: null!").ToChat(executor);
+      }
       
       await cookie.Set(steam, enable ? "Y" : "N");
       await Server.NextFrameAsync(() => {

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -73,19 +73,32 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
   public void Command_AutoRTD(CCSPlayerController? executor, CommandInfo info) {
     if (executor == null) return;
 
-    if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
-      rtdLocale.RollingDisabled().ToChat(executor);
-      return;
-    }
-
     rtdLocale.DebugPrintMessage($"You are bypassing permission checks. Do NOT let this go into release. Remove the commented lines.").ToChat(executor);
+    // if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
+    //   rtdLocale.RollingDisabled().ToChat(executor);
+    //   return;
+    // }
+
     // if (!AdminManager.PlayerHasPermissions(executor, CV_AUTORTD_FLAG.Value)) {
     //   generic.NoPermissionMessage(CV_AUTORTD_FLAG.Value).ToChat(executor);
     //   return;
     // }
 
     if (cookie == null) {
-      locale.TogglingNotEnabled.ToChat(executor);
+      //locale.TogglingNotEnabled.ToChat(executor);
+      rtdLocale.DebugPrintMessage($"Cookie was null. Trying to get again...").ToChat(executor);
+      
+      // try again to get cookie
+      Task.Run(async () => {
+        if (API.Actain != null)
+          cookie = await API.Actain.getCookieService()
+           .RegClientCookie("jb_rtd_auto");
+      });
+
+      if (cookie == null) {
+        rtdLocale.DebugPrintMessage($"Failed again to get cookie.").ToChat(executor);
+      }
+      
       return;
     }
 

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -5,7 +5,6 @@ using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Modules.Cvars;
-using Jailbreak.Formatting.Base;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
 using Jailbreak.Formatting.Views.RTD;

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -73,21 +73,22 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
   public void Command_AutoRTD(CCSPlayerController? executor, CommandInfo info) {
     if (executor == null) return;
 
-    if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
-      rtdLocale.RollingDisabled().ToChat(executor);
-      return;
-    }
+    // if (RTDCommand.CV_RTD_ENABLED.Value == -1) {
+    //   rtdLocale.RollingDisabled().ToChat(executor);
+    //   return;
+    // }
 
-    rtdLocale.DebugPrintMessage($"You are bypassing permission checks. Do NOT let this go into release. Remove the commented lines.").ToChat(executor);
     // if (!AdminManager.PlayerHasPermissions(executor, CV_AUTORTD_FLAG.Value)) {
     //   generic.NoPermissionMessage(CV_AUTORTD_FLAG.Value).ToChat(executor);
     //   return;
     // }
 
-    if (cookie == null) {
-      locale.TogglingNotEnabled.ToChat(executor);
-      return;
-    }
+    // if (cookie == null) {
+    //   locale.TogglingNotEnabled.ToChat(executor);
+    //   return;
+    // }
+    
+    rtdLocale.DebugPrintMessage($"You are bypassing important checks. Do NOT let this go into release. Remove the commented lines.").ToChat(executor);
 
     var steam = executor.SteamID;
     Task.Run(async () => {
@@ -103,11 +104,7 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
       var enable = value is not (null or "Y");
       
       // Debugging enable value
-      if (enable != null) {
-        rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
-      } else {
-        rtdLocale.DebugPrintMessage($"Enable was: null!").ToChat(executor);
-      }
+      rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
       
       await cookie.Set(steam, enable ? "Y" : "N");
       await Server.NextFrameAsync(() => {

--- a/mod/Jailbreak.RTD/AutoRTD.cs
+++ b/mod/Jailbreak.RTD/AutoRTD.cs
@@ -116,11 +116,7 @@ public class AutoRTD(IRTDRewarder rewarder, IAutoRTDLocale locale,
       var enable = value is not (null or "Y");
       
       // Debugging enable value
-      if (enable != null) {
-        rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
-      } else {
-        rtdLocale.DebugPrintMessage($"Enable was: null!").ToChat(executor);
-      }
+      rtdLocale.DebugPrintMessage($"Enable was: {enable}!").ToChat(executor);
       
       await cookie.Set(steam, enable ? "Y" : "N");
       await Server.NextFrameAsync(() => {


### PR DESCRIPTION
Tries to get cookie again if it failed on start. Mainly for debugging purposes, only seems to be happening on dev server.