### PR TITLE
Feat: Auto-Warden DS Perk

### DIFF
--- a/mod/Jailbreak.LastRequest/LastRequestRebelCommand.cs
+++ b/mod/Jailbreak.LastRequest/LastRequestRebelCommand.cs
@@ -64,6 +64,15 @@ public class LastRequestRebelCommand(ILastRequestManager lastRequestManager,
       return;
     }
 
+    if (Utilities.GetPlayers()
+       .Count(p
+          => p.IsReal() && p is { PawnIsAlive: true, Team: CsTeam.Terrorist })
+      > 1) {
+      messages.CannotLR("You must be the last alive to !rebel")
+       .ToChat(rebeller);
+      return;
+    }
+
     if (rebeller.Pawn.Value != null)
       rebellerHealths[rebeller.Slot] = rebeller.Pawn.Value.Health;
     lastRequestRebelManager.StartLRRebelling(rebeller);

--- a/mod/Jailbreak.LastRequest/LastRequests/GunToss.cs
+++ b/mod/Jailbreak.LastRequest/LastRequests/GunToss.cs
@@ -56,6 +56,13 @@ public class GunToss(BasePlugin plugin, ILastRequestManager manager,
     }
 
     if (prisonerTossed && guardTossed) bothThrewTick = Server.TickCount;
+
+    if (bothThrewTick > 0)
+      Plugin.AddTimer(5, () => {
+        if (State != LRState.ACTIVE) return;
+        Guard.SetHealth(Math.Min(Guard.Health, 100));
+        Guard.SetArmor(Math.Min(Guard.PawnArmor, 100));
+      });
   }
 
   public override void Setup() {
@@ -63,6 +70,13 @@ public class GunToss(BasePlugin plugin, ILastRequestManager manager,
 
     Prisoner.RemoveWeapons();
     Guard.RemoveWeapons();
+
+    Server.NextFrame(() => {
+      if (!Guard.IsValid) return;
+
+      Guard.SetHealth(500);
+      Guard.SetArmor(500);
+    });
 
     Plugin.AddTimer(3, Execute);
   }

--- a/mod/Jailbreak.LastRequest/LastRequests/GunToss.cs
+++ b/mod/Jailbreak.LastRequest/LastRequests/GunToss.cs
@@ -60,7 +60,7 @@ public class GunToss(BasePlugin plugin, ILastRequestManager manager,
     if (bothThrewTick > 0)
       Plugin.AddTimer(5, () => {
         if (State != LRState.ACTIVE) return;
-        Guard.SetHealth(Math.Min(Guard.Health, 100));
+        Guard.SetHealth(Math.Min(Guard.PlayerPawn.Value!.Health, 100));
         Guard.SetArmor(Math.Min(Guard.PawnArmor, 100));
       });
   }

--- a/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
@@ -1,11 +1,9 @@
-﻿using CounterStrikeSharp.API;
+﻿using System;
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Admin;
 using CounterStrikeSharp.API.Modules.Commands;
-using CounterStrikeSharp.API;
-using CounterStrikeSharp.API.Core;
-using CounterStrikeSharp.API.Modules.Entities;
 using CounterStrikeSharp.API.Modules.Utils;
 using Jailbreak.Formatting.Extensions;
 using Jailbreak.Formatting.Views;
@@ -14,7 +12,6 @@ using Jailbreak.Public.Behaviors;
 using Jailbreak.Public.Mod.Mute;
 using Jailbreak.Public.Mod.Warden;
 using CounterStrikeSharp.API.Modules.Cvars;
-using CounterStrikeSharp.API.Modules.Memory.DynamicFunctions;
 using Jailbreak.Formatting.Base;
 using Jailbreak.Formatting.Core;
 using Jailbreak.Formatting.Objects;
@@ -51,11 +48,13 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
     if (command.ArgCount == 2) {
       if (!int.TryParse(command.GetArg(1), out countdownDuration)) {
         generics.InvalidParameter(command.GetArg(1), "number");
+        command.ReplyToCommand("Expected a number parameter.");
         return;
       }
 
       if (countdownDuration <= 0) {
         generics.InvalidParameter(command.GetArg(1), "number greater than 0");
+        command.ReplyToCommand("Expected a number greater than 0.");
         return;
       }
     }
@@ -63,12 +62,14 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
     if (countdownDuration < CV_WARDEN_MIN_COUNTDOWN.Value) {
       generics.InvalidParameter(command.GetArg(1), 
         $"number greater than or equal to {CV_WARDEN_MIN_COUNTDOWN.Value}");
+      command.ReplyToCommand($"Expected a number greater than or equal to {CV_WARDEN_MIN_COUNTDOWN.Value}");
       return;
     }
     
     if (countdownDuration > CV_WARDEN_MAX_COUNTDOWN.Value) {
       generics.InvalidParameter(command.GetArg(1), 
         $"number less than or equal to {CV_WARDEN_MAX_COUNTDOWN.Value}");
+      command.ReplyToCommand($"Expected a number less than or equal to {CV_WARDEN_MAX_COUNTDOWN.Value}");
       return;
     }
     //
@@ -136,7 +137,6 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
 
     if (!fromWarden
       && AdminManager.PlayerHasPermissions(executor, "@css/chat")) {
-      wardenLocale.NotWarden.ToChat(executor);
       mute.PeaceMute(MuteReason.ADMIN);
       lastCountdown = DateTime.Now;
       return true;
@@ -152,7 +152,9 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
       mute.PeaceMute(fromWarden ? MuteReason.WARDEN_INVOKED : MuteReason.ADMIN);
       lastCountdown = DateTime.Now;
       return true;  
-    } 
+    } else {
+      wardenLocale.NotWarden.ToChat(executor);
+    }
     return false;
   }
 }

--- a/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
@@ -103,19 +103,19 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
   private void PrintCountdownToPlayers(int seconds) {
     new SimpleView { PREFIX, "Countdown: " + seconds }.ToAllChat();
     
-    var players = Utilities.GetPlayers();
-    foreach (var player in players) {
-      player.ExecuteClientCommand("play buttons\\blip1");
-    }
+    // var players = Utilities.GetPlayers();
+    // foreach (var player in players) {
+    //   player.ExecuteClientCommand("play buttons\\blip1");
+    // }
   }
 
   private void PrintGoToPlayers() {
     new SimpleView { PREFIX, "GO! GO! GO!" }.ToAllChat();
     
-    var players = Utilities.GetPlayers();
-    foreach (var player in players) {
-      player.ExecuteClientCommand("play \\sounds\\vo\\agents\\balkan\\radio_letsgo01.vsnd_c");
-    }
+    // var players = Utilities.GetPlayers();
+    // foreach (var player in players) {
+    //   player.ExecuteClientCommand("play \\sounds\\vo\\agents\\balkan\\radio_letsgo01.vsnd_c");
+    // }
   }
   //
   

--- a/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
@@ -73,8 +73,8 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
     }
     //
     
-    // Attempt to enact peace
-    bool success = EnactPeace(executor);
+    // Check perm and enact peace
+    bool success = PermCheckAndEnactPeace(executor);
     if (!success) return;
     
     // Inform players of countdown
@@ -92,7 +92,7 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
   // Is this okay?
   // Feels like bad encapsulation
   private static readonly FormatObject PREFIX =
-    new HiddenFormatObject($" {ChatColors.Red}Countdown>") {
+    new HiddenFormatObject($" {ChatColors.DarkBlue}Countdown>") {
       Plain = false, Panorama = false, Chat = true
     };
 
@@ -101,7 +101,12 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
   }
   
   private void PrintCountdownToPlayers(int seconds) {
-    new SimpleView { PREFIX, "Countdown: " + seconds }.ToAllChat();
+    if (seconds <= 5) {
+      new SimpleView { PREFIX, seconds.ToString() }.ToAllChat();  
+    }
+    else if (seconds % 5 == 0) {
+      new SimpleView { PREFIX, seconds.ToString() }.ToAllChat();
+    }
     
     // var players = Utilities.GetPlayers();
     // foreach (var player in players) {
@@ -119,8 +124,8 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
   }
   //
   
-  // Attempt to enact a period of peace for players to focus on the countdown
-  private bool EnactPeace(CCSPlayerController? executor) {
+  // Check permissions and attempt to enact a period of peace for players to focus on the countdown
+  private bool PermCheckAndEnactPeace(CCSPlayerController? executor) {
     var fromWarden = executor != null && warden.IsWarden(executor);
 
     if (executor == null
@@ -145,8 +150,11 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
       return false;
     }
 
-    mute.PeaceMute(fromWarden ? MuteReason.WARDEN_INVOKED : MuteReason.ADMIN);
-    lastCountdown = DateTime.Now;
-    return true;
+    if (fromWarden) {
+      mute.PeaceMute(fromWarden ? MuteReason.WARDEN_INVOKED : MuteReason.ADMIN);
+      lastCountdown = DateTime.Now;
+      return true;  
+    } 
+    return false;
   }
 }

--- a/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
+++ b/mod/Jailbreak.Warden/Commands/CountdownCommandBehavior.cs
@@ -80,11 +80,14 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
     // Inform players of countdown
     StartCountDown(countdownDuration);
     
-    // Create callbacks each second to notify players of countdown time remaining / completion of countdown
+    // Create callbacks each second less than 5 or divisible by 5 to notify players of countdown time remaining / completion of countdown
     for (int i = countdownDuration; i > 0; --i) {
       int current = i; // lambda capture
-      Server.RunOnTick(Server.TickCount + (64 * (countdownDuration - current)), 
-        () => PrintCountdownToPlayers(current));
+
+      if (current <= 5 || current % 5 == 0) {
+          Server.RunOnTick(Server.TickCount + (64 * (countdownDuration - current)), 
+            () => PrintCountdownToPlayers(current));  
+      }
     }
     Server.RunOnTick(Server.TickCount + (64 * countdownDuration), () => PrintGoToPlayers());
   }
@@ -101,12 +104,7 @@ public class CountdownCommandBehavior(IWardenService warden, IMuteService mute,
   }
   
   private void PrintCountdownToPlayers(int seconds) {
-    if (seconds <= 5) {
-      new SimpleView { PREFIX, seconds.ToString() }.ToAllChat();  
-    }
-    else if (seconds % 5 == 0) {
-      new SimpleView { PREFIX, seconds.ToString() }.ToAllChat();
-    }
+    new SimpleView { PREFIX, seconds.ToString() }.ToAllChat();  
     
     // var players = Utilities.GetPlayers();
     // foreach (var player in players) {

--- a/mod/Jailbreak.Warden/Selection/AutoWarden.cs
+++ b/mod/Jailbreak.Warden/Selection/AutoWarden.cs
@@ -60,12 +60,11 @@ public class AutoWarden(IWardenSelectionService selectionService,
         if (player.PlayerPawn.Value?.AbsOrigin != null) 
           ctSpawns[player] = player.PlayerPawn.Value.AbsOrigin;
       }
-      Server.ExecuteCommand("echo EventRoundPoststart Called");
     });
 
     plugin.AddTimer(CV_AUTOWARDEN_DELAY_INTERVAL.Value-1, () => {
       foreach (var (player, spawn) in ctSpawns) {
-        if (player.AbsOrigin == spawn) continue;
+        if ((player.AbsOrigin! - spawn).LengthSqr() < 10.0f) continue; // 3 Units Tolerance
         if (!cachedCookies.ContainsKey(player.SteamID))
           Task.Run(async () => await populateCache(player, player.SteamID));
 

--- a/mod/Jailbreak.Warden/Selection/AutoWarden.cs
+++ b/mod/Jailbreak.Warden/Selection/AutoWarden.cs
@@ -60,6 +60,7 @@ public class AutoWarden(IWardenSelectionService selectionService,
         if (player.PlayerPawn.Value?.AbsOrigin != null) 
           ctSpawns[player] = player.PlayerPawn.Value.AbsOrigin;
       }
+      Server.ExecuteCommand("echo EventRoundPoststart Called");
     });
 
     plugin.AddTimer(CV_AUTOWARDEN_DELAY_INTERVAL.Value-1, () => {

--- a/mod/Jailbreak.Warden/Selection/AutoWarden.cs
+++ b/mod/Jailbreak.Warden/Selection/AutoWarden.cs
@@ -57,7 +57,8 @@ public class AutoWarden(IWardenSelectionService selectionService,
           && p.IsReal()
           && p.PawnIsAlive
           && AdminManager.PlayerHasPermissions(p, CV_AUTOWARDEN_FLAG.Value))) {
-        if (player.AbsOrigin != null) ctSpawns[player] = player.AbsOrigin;
+        if (player.PlayerPawn.Value?.AbsOrigin != null) 
+          ctSpawns[player] = player.PlayerPawn.Value.AbsOrigin;
       }
     });
 

--- a/mod/Jailbreak.Warden/Selection/AutoWarden.cs
+++ b/mod/Jailbreak.Warden/Selection/AutoWarden.cs
@@ -38,7 +38,7 @@ public class AutoWarden(IWardenSelectionService selectionService,
     
     TryLoadCookie();
     basePlugin.RegisterListener<Listeners.OnMapStart>(OnMapStart);
-    basePlugin.RegisterEventHandler<EventRoundStart>(OnRoundStart);
+    basePlugin.RegisterEventHandler<EventRoundPoststart>(OnRoundStart);
   }
   
   public void Dispose() { }
@@ -50,7 +50,7 @@ public class AutoWarden(IWardenSelectionService selectionService,
     else plugin.RemoveListener<Listeners.OnMapStart>(OnMapStart);
   }
 
-  private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info) {
+  private HookResult OnRoundStart(EventRoundPoststart @event, GameEventInfo info) {
     plugin.AddTimer(1f, () => {
       foreach (var player in Utilities.GetPlayers()
        .Where(p => p.Team == CsTeam.CounterTerrorist 

--- a/mod/Jailbreak.Warden/Selection/AutoWarden.cs
+++ b/mod/Jailbreak.Warden/Selection/AutoWarden.cs
@@ -51,7 +51,9 @@ public class AutoWarden(IWardenSelectionService selectionService,
   }
 
   private HookResult OnRoundStart(EventRoundPoststart @event, GameEventInfo info) {
-    plugin.AddTimer(1f, () => {
+    ctSpawns.Clear();
+    
+    plugin.AddTimer(2f, () => {
       foreach (var player in Utilities.GetPlayers()
        .Where(p => p.Team == CsTeam.CounterTerrorist 
           && p.IsReal()
@@ -64,7 +66,7 @@ public class AutoWarden(IWardenSelectionService selectionService,
 
     plugin.AddTimer(CV_AUTOWARDEN_DELAY_INTERVAL.Value-1, () => {
       foreach (var (player, spawn) in ctSpawns) {
-        if ((player.AbsOrigin! - spawn).LengthSqr() < 10.0f) continue; // 3 Units Tolerance
+        if ((player.PlayerPawn.Value?.AbsOrigin! - spawn).LengthSqr() < 10.0f) continue; // 3 Units Tolerance
         if (!cachedCookies.ContainsKey(player.SteamID))
           Task.Run(async () => await populateCache(player, player.SteamID));
 


### PR DESCRIPTION
Auto-Warden perk for Silver+ Dedicated Supporters (DS).
If a DS player has moved from their spawn point after a short period at round start, they are automatically entered into the warden raffle without needing to manually opt-in.