### PR TITLE
Special Days Revamp

### DIFF
--- a/lang/Jailbreak.English/SpecialDay/FogDayLocale.cs
+++ b/lang/Jailbreak.English/SpecialDay/FogDayLocale.cs
@@ -1,0 +1,26 @@
+using Jailbreak.Formatting.Base;
+
+namespace Jailbreak.English.SpecialDay;
+
+public class FogDayLocale() : SoloDayLocale("Fog War",
+  "A heavy fog is creeping in...", "Your visibility will be gone soon.",
+  "Fog expands periodically — Stay alert.") {
+
+  public IView FogComingIn() {
+    return new SimpleView {
+      PREFIX, 
+      "Fog's rolling in!", 
+      "Match Starts in 15 seconds."
+    };
+  }
+
+  public IView FogExpandsIn(int seconds) {
+    if (seconds == 0) return new SimpleView { PREFIX, "Fog is expanding." };
+    return new SimpleView {
+      PREFIX,
+      "Fog will start expanding in",
+      seconds,
+      "second" + (seconds == 1 ? "" : "s")
+    };
+  }
+}

--- a/mod/Jailbreak.SpecialDay/Jailbreak.SpecialDay.csproj
+++ b/mod/Jailbreak.SpecialDay/Jailbreak.SpecialDay.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
@@ -15,6 +15,7 @@ public class SpecialDayFactory(IServiceProvider provider) : ISpecialDayFactory {
       SDType.BHOP      => new BHopDay(plugin, provider),
       SDType.CUSTOM    => new CustomDay(plugin, provider),
       SDType.FFA       => new FFADay(plugin, provider),
+      SDType.FOG       => new FogDay(plugin, provider),
       SDType.GUNGAME   => new GunGameDay(plugin, provider),
       SDType.HE        => new HEDay(plugin, provider),
       SDType.HNS       => new HideAndSeekDay(plugin, provider),

--- a/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
@@ -18,7 +18,7 @@ public class SpecialDayFactory(IServiceProvider provider) : ISpecialDayFactory {
       SDType.GUNGAME   => new GunGameDay(plugin, provider),
       SDType.HE        => new HEDay(plugin, provider),
       SDType.HNS       => new HideAndSeekDay(plugin, provider),
-      // SDType.INFECTION => new InfectionDay(plugin, provider),
+      SDType.INFECTION => new InfectionDay(plugin, provider),
       SDType.NOSCOPE   => new NoScopeDay(plugin, provider),
       SDType.OITC      => new OneInTheChamberDay(plugin, provider),
       SDType.SPEEDRUN  => new SpeedrunDay(plugin, provider),

--- a/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDayFactory.cs
@@ -16,6 +16,7 @@ public class SpecialDayFactory(IServiceProvider provider) : ISpecialDayFactory {
       SDType.CUSTOM    => new CustomDay(plugin, provider),
       SDType.FFA       => new FFADay(plugin, provider),
       SDType.GUNGAME   => new GunGameDay(plugin, provider),
+      SDType.HE        => new HEDay(plugin, provider),
       SDType.HNS       => new HideAndSeekDay(plugin, provider),
       // SDType.INFECTION => new InfectionDay(plugin, provider),
       SDType.NOSCOPE   => new NoScopeDay(plugin, provider),

--- a/mod/Jailbreak.SpecialDay/SpecialDays/FogDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/FogDay.cs
@@ -11,174 +11,179 @@ using Jailbreak.Public.Mod.SpecialDay.Enums;
 
 namespace Jailbreak.SpecialDay.SpecialDays;
 
-public class FogDay(BasePlugin plugin, IServiceProvider provider) 
+public class FogDay(BasePlugin plugin, IServiceProvider provider)
   : AbstractSpecialDay(plugin, provider), ISpecialDayMessageProvider {
   public override SDType Type => SDType.FOG;
   private FogDayLocale Msg => (FogDayLocale)Locale;
   public ISDInstanceLocale Locale => new FogDayLocale();
   public override SpecialDaySettings Settings => new FogSettings();
-  
+
   private CFogController? fogController;
   private nint originalSkyMat;
   private nint originalSkyMatLighting;
   private CEnvSky? skyEntity;
-    
+
   private float targetFogEnd = 2000f;
   private float fogStepPerTick;
   private bool shouldGrowFog;
 
   public override void Setup() {
-    Plugin.RegisterListener<Listeners.OnTick>(OnTick);
-    Plugin.RegisterEventHandler<EventPlayerDeath>(OnDeath);
-    
+    Plugin.RegisterListener<Listeners.OnTick>(onTick);
+    Plugin.RegisterEventHandler<EventPlayerDeath>(onDeath);
+
     setFog(true);
     setSky(true);
-    
+
     Timers[20] += () => Locale.BeginsIn(20).ToAllChat();
     Timers[25] += () => {
       Msg.FogComingIn().ToAllChat();
       setTargetFogDistance(300, 10);
     };
-    Timers[30]  += () => Msg.BeginsIn(10).ToAllChat();
-    Timers[35]  += () => Msg.BeginsIn(5).ToAllChat();
-    Timers[40]  += Execute; Msg.BeginsIn(0);
-    Timers[97]  += () => Msg.FogExpandsIn(3);
-    Timers[98]  += () => Msg.FogExpandsIn(2);
-    Timers[99]  += () => Msg.FogExpandsIn(1);
-    Timers[100] += () => setTargetFogDistance(3000, 180); Msg.FogExpandsIn(0);
-    
-    base.Setup(); 
+    Timers[30] += () => Msg.BeginsIn(10).ToAllChat();
+    Timers[35] += () => Msg.BeginsIn(5).ToAllChat();
+    Timers[40] += () => {
+      Execute();
+      Msg.BeginsIn(0);
+    };
+    Timers[97] += () => Msg.FogExpandsIn(3);
+    Timers[98] += () => Msg.FogExpandsIn(2);
+    Timers[99] += () => Msg.FogExpandsIn(1);
+    Timers[100] += () => {
+      setTargetFogDistance(3000, 180);
+      Msg.FogExpandsIn(0);
+    };
+
+    base.Setup();
   }
-  
 
-  private unsafe void setSky(bool set)
-    {
-        cacheOriginalSky();
-        
-        if (skyEntity == null) return;
 
-        var mat = set ? nint.Zero : originalSkyMat;
-        var matLit = set ? nint.Zero : originalSkyMatLighting;
+  private unsafe void setSky(bool set) {
+    cacheOriginalSky();
 
-        Unsafe.Write((void*)skyEntity.SkyMaterial.Handle, mat);
-        Unsafe.Write((void*)skyEntity.SkyMaterialLightingOnly.Handle, matLit);
+    if (skyEntity == null) return;
 
-        Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_hSkyMaterial");
-        Utilities.SetStateChanged(skyEntity, "CEnvSky",
-          "m_hSkyMaterialLightingOnly");
+    var mat    = set ? nint.Zero : originalSkyMat;
+    var matLit = set ? nint.Zero : originalSkyMatLighting;
 
-        skyEntity.BrightnessScale = 1.0f;
-        Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_flBrightnessScale");
+    Unsafe.Write((void*)skyEntity.SkyMaterial.Handle, mat);
+    Unsafe.Write((void*)skyEntity.SkyMaterialLightingOnly.Handle, matLit);
+
+    Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_hSkyMaterial");
+    Utilities.SetStateChanged(skyEntity, "CEnvSky",
+      "m_hSkyMaterialLightingOnly");
+
+    skyEntity.BrightnessScale = 1.0f;
+    Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_flBrightnessScale");
+  }
+
+  private void setFog(bool set) {
+    if (!set) {
+      fogController?.Remove();
+      fogController = null;
+      return;
     }
 
-    private void setFog(bool set)
-    {
-        if (!set)
-        {
-            fogController?.Remove();
-            fogController = null;
-            return;
-        }
+    fogController ??=
+      Utilities.CreateEntityByName<CFogController>("env_fog_controller");
+    fogController?.DispatchSpawn();
 
-        fogController ??=
-          Utilities.CreateEntityByName<CFogController>("env_fog_controller");
-        fogController?.DispatchSpawn();
+    if (fogController == null) return;
 
-        if (fogController == null) return;
+    var fog = fogController.Fog;
+    fog.Enable       = true;
+    fog.Blend        = true;
+    fog.ColorPrimary = Color.Black;
+    fog.Exponent     = 0.1f;
+    fog.Maxdensity   = 1f;
+    fog.Start        = 0;
+    fog.End          = 300;
+    fog.Farz         = 310;
 
-        var fog = fogController.Fog;
-        fog.Enable = true;
-        fog.Blend = true;
-        fog.ColorPrimary = Color.Black;
-        fog.Exponent = 0.1f;
-        fog.Maxdensity = 1f;
-        fog.Start = 0;
-        fog.End = 300;
-        fog.Farz = 310;
-
-        foreach (var field in new[]
-                 {
-                     "colorPrimary", "start", "end", "farz",
-                     "maxdensity", "exponent", "enable", "blend",
-                 })
-        {
-            Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
-                Schema.GetSchemaOffset("fogparams_t", field));
-        }
-
-        var vis = Utilities
-         .FindAllEntitiesByDesignerName<CPlayerVisibility>(
-            "env_player_visibility")
-         .FirstOrDefault();
-        if (vis != null)
-        {
-            vis.FogMaxDensityMultiplier = 1f;
-            Utilities.SetStateChanged(vis, "CPlayerVisibility",
-              "m_flFogMaxDensityMultiplier");
-        }
-
-        foreach (var pawn in Utilities.GetPlayers()
-         .Select(p => p.Pawn.Value)
-         .OfType<CBasePlayerPawn>())
-          pawn.AcceptInput("SetFogController", activator: fogController,
-            value: "!activator");
-    }
-
-    private void OnTick() {
-      if (!shouldGrowFog || fogController == null)
-        return;
-
-      var fog = fogController.Fog;
-
-      if (Math.Abs(fog.End - targetFogEnd) < Math.Abs(fogStepPerTick)) {
-        fog.End        = targetFogEnd;
-        fog.Farz       = targetFogEnd * 1.04f;
-        shouldGrowFog = false;
-      } else {
-        fog.End  += fogStepPerTick;
-        fog.Farz =  fog.End + 10f;
-      }
-
+    foreach (var field in new[] {
+      "colorPrimary", "start", "end", "farz", "maxdensity", "exponent",
+      "enable", "blend",
+    }) {
       Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
-        Schema.GetSchemaOffset("fogparams_t", "end"));
-      Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
-        Schema.GetSchemaOffset("fogparams_t", "farz"));
+        Schema.GetSchemaOffset("fogparams_t", field));
     }
 
-    private HookResult OnDeath(EventPlayerDeath @event, GameEventInfo info) {
-      var pawn = @event.Userid?.PlayerPawn.Value;
-      if (pawn == null) return HookResult.Continue;
-      
-      Server.NextFrame(() => {
-        pawn.AcceptInput("SetFogController", activator: fogController,
-          value: "!activator");
-      });
-      return HookResult.Continue;
-    }   
-    private unsafe void cacheOriginalSky() {
-      skyEntity = Utilities.FindAllEntitiesByDesignerName<CEnvSky>("env_sky")
-       .FirstOrDefault();
-      if (skyEntity == null) return;
-
-      originalSkyMat = Unsafe.Read<nint>((void*)skyEntity.SkyMaterial.Handle);
-      originalSkyMatLighting =
-        Unsafe.Read<nint>((void*)skyEntity.SkyMaterialLightingOnly.Handle);
+    var vis = Utilities
+     .FindAllEntitiesByDesignerName<CPlayerVisibility>("env_player_visibility")
+     .FirstOrDefault();
+    if (vis != null) {
+      vis.FogMaxDensityMultiplier = 1f;
+      Utilities.SetStateChanged(vis, "CPlayerVisibility",
+        "m_flFogMaxDensityMultiplier");
     }
-    
-    private void setTargetFogDistance(int distance, float durationInSeconds)
-    {
-      if (fogController == null)
-        return;
 
-      var currentEnd = fogController.Fog.End;
-      var totalTicks = durationInSeconds * 64f;
-      fogStepPerTick = (distance - currentEnd) / totalTicks;
-      targetFogEnd   = distance;
-      shouldGrowFog  = true;
+    foreach (var pawn in Utilities.GetPlayers()
+     .Select(p => p.Pawn.Value)
+     .OfType<CBasePlayerPawn>())
+      pawn.AcceptInput("SetFogController", activator: fogController,
+        value: "!activator");
+  }
+
+  private void onTick() {
+    if (!shouldGrowFog || fogController == null) return;
+
+    var fog = fogController.Fog;
+
+    if (Math.Abs(fog.End - targetFogEnd) < Math.Abs(fogStepPerTick)) {
+      fog.End       = targetFogEnd;
+      fog.Farz      = targetFogEnd * 1.04f;
+      shouldGrowFog = false;
+    } else {
+      fog.End  += fogStepPerTick;
+      fog.Farz =  fog.End + 10f;
     }
+
+    Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
+      Schema.GetSchemaOffset("fogparams_t", "end"));
+    Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
+      Schema.GetSchemaOffset("fogparams_t", "farz"));
+  }
+
+  private HookResult onDeath(EventPlayerDeath @event, GameEventInfo info) {
+    var pawn = @event.Userid?.PlayerPawn.Value;
+    if (pawn == null) return HookResult.Continue;
+
+    Server.NextFrame(() => {
+      pawn.AcceptInput("SetFogController", activator: fogController,
+        value: "!activator");
+    });
+    return HookResult.Continue;
+  }
+
+  override protected HookResult OnEnd(EventRoundEnd @event,
+    GameEventInfo info) {
+    Plugin.RemoveListener<Listeners.OnTick>(onTick);
+    Plugin.DeregisterEventHandler<EventPlayerDeath>(onDeath);
+    return base.OnEnd(@event, info);
+  }
+
+  private unsafe void cacheOriginalSky() {
+    skyEntity = Utilities.FindAllEntitiesByDesignerName<CEnvSky>("env_sky")
+     .FirstOrDefault();
+    if (skyEntity == null) return;
+
+    originalSkyMat = Unsafe.Read<nint>((void*)skyEntity.SkyMaterial.Handle);
+    originalSkyMatLighting =
+      Unsafe.Read<nint>((void*)skyEntity.SkyMaterialLightingOnly.Handle);
+  }
+
+  private void setTargetFogDistance(int distance, float durationInSeconds) {
+    if (fogController == null) return;
+
+    var currentEnd = fogController.Fog.End;
+    var totalTicks = durationInSeconds * 64f;
+    fogStepPerTick = (distance - currentEnd) / totalTicks;
+    targetFogEnd   = distance;
+    shouldGrowFog  = true;
+  }
+
   public class FogSettings : SpecialDaySettings {
     private readonly Random rng;
-    
+
     public FogSettings() {
       TTeleport    = TeleportType.ARMORY;
       CtTeleport   = TeleportType.ARMORY;
@@ -187,7 +192,7 @@ public class FogDay(BasePlugin plugin, IServiceProvider provider)
       rng          = new Random();
       WithFriendlyFire();
     }
-    
+
     public override float FreezeTime(CCSPlayerController player) {
       return rng.NextSingle() * 5 + 2;
     }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/FogDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/FogDay.cs
@@ -1,0 +1,195 @@
+using System.Drawing;
+using System.Runtime.CompilerServices;
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Memory;
+using Jailbreak.English.SpecialDay;
+using Jailbreak.Formatting.Extensions;
+using Jailbreak.Formatting.Views.SpecialDay;
+using Jailbreak.Public.Mod.SpecialDay;
+using Jailbreak.Public.Mod.SpecialDay.Enums;
+
+namespace Jailbreak.SpecialDay.SpecialDays;
+
+public class FogDay(BasePlugin plugin, IServiceProvider provider) 
+  : AbstractSpecialDay(plugin, provider), ISpecialDayMessageProvider {
+  public override SDType Type => SDType.FOG;
+  private FogDayLocale Msg => (FogDayLocale)Locale;
+  public ISDInstanceLocale Locale => new FogDayLocale();
+  public override SpecialDaySettings Settings => new FogSettings();
+  
+  private CFogController? fogController;
+  private nint originalSkyMat;
+  private nint originalSkyMatLighting;
+  private CEnvSky? skyEntity;
+    
+  private float targetFogEnd = 2000f;
+  private float fogStepPerTick;
+  private bool shouldGrowFog;
+
+  public override void Setup() {
+    Plugin.RegisterListener<Listeners.OnTick>(OnTick);
+    Plugin.RegisterEventHandler<EventPlayerDeath>(OnDeath);
+    
+    setFog(true);
+    setSky(true);
+    
+    Timers[20] += () => Locale.BeginsIn(20).ToAllChat();
+    Timers[25] += () => {
+      Msg.FogComingIn().ToAllChat();
+      setTargetFogDistance(300, 10);
+    };
+    Timers[30]  += () => Msg.BeginsIn(10).ToAllChat();
+    Timers[35]  += () => Msg.BeginsIn(5).ToAllChat();
+    Timers[40]  += Execute; Msg.BeginsIn(0);
+    Timers[97]  += () => Msg.FogExpandsIn(3);
+    Timers[98]  += () => Msg.FogExpandsIn(2);
+    Timers[99]  += () => Msg.FogExpandsIn(1);
+    Timers[100] += () => setTargetFogDistance(3000, 180); Msg.FogExpandsIn(0);
+    
+    base.Setup(); 
+  }
+  
+
+  private unsafe void setSky(bool set)
+    {
+        cacheOriginalSky();
+        
+        if (skyEntity == null) return;
+
+        var mat = set ? nint.Zero : originalSkyMat;
+        var matLit = set ? nint.Zero : originalSkyMatLighting;
+
+        Unsafe.Write((void*)skyEntity.SkyMaterial.Handle, mat);
+        Unsafe.Write((void*)skyEntity.SkyMaterialLightingOnly.Handle, matLit);
+
+        Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_hSkyMaterial");
+        Utilities.SetStateChanged(skyEntity, "CEnvSky",
+          "m_hSkyMaterialLightingOnly");
+
+        skyEntity.BrightnessScale = 1.0f;
+        Utilities.SetStateChanged(skyEntity, "CEnvSky", "m_flBrightnessScale");
+    }
+
+    private void setFog(bool set)
+    {
+        if (!set)
+        {
+            fogController?.Remove();
+            fogController = null;
+            return;
+        }
+
+        fogController ??=
+          Utilities.CreateEntityByName<CFogController>("env_fog_controller");
+        fogController?.DispatchSpawn();
+
+        if (fogController == null) return;
+
+        var fog = fogController.Fog;
+        fog.Enable = true;
+        fog.Blend = true;
+        fog.ColorPrimary = Color.Black;
+        fog.Exponent = 0.1f;
+        fog.Maxdensity = 1f;
+        fog.Start = 0;
+        fog.End = 300;
+        fog.Farz = 310;
+
+        foreach (var field in new[]
+                 {
+                     "colorPrimary", "start", "end", "farz",
+                     "maxdensity", "exponent", "enable", "blend",
+                 })
+        {
+            Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
+                Schema.GetSchemaOffset("fogparams_t", field));
+        }
+
+        var vis = Utilities
+         .FindAllEntitiesByDesignerName<CPlayerVisibility>(
+            "env_player_visibility")
+         .FirstOrDefault();
+        if (vis != null)
+        {
+            vis.FogMaxDensityMultiplier = 1f;
+            Utilities.SetStateChanged(vis, "CPlayerVisibility",
+              "m_flFogMaxDensityMultiplier");
+        }
+
+        foreach (var pawn in Utilities.GetPlayers()
+         .Select(p => p.Pawn.Value)
+         .OfType<CBasePlayerPawn>())
+          pawn.AcceptInput("SetFogController", activator: fogController,
+            value: "!activator");
+    }
+
+    private void OnTick() {
+      if (!shouldGrowFog || fogController == null)
+        return;
+
+      var fog = fogController.Fog;
+
+      if (Math.Abs(fog.End - targetFogEnd) < Math.Abs(fogStepPerTick)) {
+        fog.End        = targetFogEnd;
+        fog.Farz       = targetFogEnd * 1.04f;
+        shouldGrowFog = false;
+      } else {
+        fog.End  += fogStepPerTick;
+        fog.Farz =  fog.End + 10f;
+      }
+
+      Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
+        Schema.GetSchemaOffset("fogparams_t", "end"));
+      Utilities.SetStateChanged(fogController, "CFogController", "m_fog",
+        Schema.GetSchemaOffset("fogparams_t", "farz"));
+    }
+
+    private HookResult OnDeath(EventPlayerDeath @event, GameEventInfo info) {
+      var pawn = @event.Userid?.PlayerPawn.Value;
+      if (pawn == null) return HookResult.Continue;
+      
+      Server.NextFrame(() => {
+        pawn.AcceptInput("SetFogController", activator: fogController,
+          value: "!activator");
+      });
+      return HookResult.Continue;
+    }   
+    private unsafe void cacheOriginalSky() {
+      skyEntity = Utilities.FindAllEntitiesByDesignerName<CEnvSky>("env_sky")
+       .FirstOrDefault();
+      if (skyEntity == null) return;
+
+      originalSkyMat = Unsafe.Read<nint>((void*)skyEntity.SkyMaterial.Handle);
+      originalSkyMatLighting =
+        Unsafe.Read<nint>((void*)skyEntity.SkyMaterialLightingOnly.Handle);
+    }
+    
+    private void setTargetFogDistance(int distance, float durationInSeconds)
+    {
+      if (fogController == null)
+        return;
+
+      var currentEnd = fogController.Fog.End;
+      var totalTicks = durationInSeconds * 64f;
+      fogStepPerTick = (distance - currentEnd) / totalTicks;
+      targetFogEnd   = distance;
+      shouldGrowFog  = true;
+    }
+  public class FogSettings : SpecialDaySettings {
+    private readonly Random rng;
+    
+    public FogSettings() {
+      TTeleport    = TeleportType.ARMORY;
+      CtTeleport   = TeleportType.ARMORY;
+      OpenCells    = true;
+      StripToKnife = false;
+      rng          = new Random();
+      WithFriendlyFire();
+    }
+    
+    public override float FreezeTime(CCSPlayerController player) {
+      return rng.NextSingle() * 5 + 2;
+    }
+  }
+}

--- a/mod/Jailbreak.SpecialDay/SpecialDays/GhostDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/GhostDay.cs
@@ -1,0 +1,100 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Cvars;
+using CounterStrikeSharp.API.Modules.Timers;
+using CounterStrikeSharp.API.Modules.Utils;
+using Jailbreak.English.SpecialDay;
+using Jailbreak.Formatting.Views.SpecialDay;
+using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.SpecialDay.Enums;
+using Jailbreak.Public.Utils;
+using Jailbreak.Validator;
+using Timer = CounterStrikeSharp.API.Modules.Timers.Timer;
+
+namespace Jailbreak.SpecialDay.SpecialDays;
+
+public class GhostDay(BasePlugin plugin, IServiceProvider provider)
+  : FFADay(plugin, provider), ISpecialDayMessageProvider {
+  public static readonly FakeConVar<float> CV_VISIBLE_DURATION = new(
+    "jb_sd_ghost_visible_duration",
+    "Amount of time players spend visible per cycle", 5f,
+    ConVarFlags.FCVAR_NONE, new NonZeroRangeValidator<float>(1f, 30f));
+  
+  public static readonly FakeConVar<float> CV_INVISIBLE_DURATION = new(
+    "jb_sd_ghost_invisible_duration",
+    "Amount of time players spend invisible per cycle", 5f,
+    ConVarFlags.FCVAR_NONE, new NonZeroRangeValidator<float>(1f, 30f));
+
+  public static float CycleDuration
+    => CV_VISIBLE_DURATION.Value + CV_INVISIBLE_DURATION.Value;
+  private bool allPlayersVisible;
+  private float timeElapsed;
+  private Timer? ghostTimer;
+  public override SDType Type => SDType.GHOST;
+  
+  public virtual ISDInstanceLocale Locale
+    => new SoloDayLocale("Ghost War",
+      "Now you see me… now you don’t! Fight through flickering visibility!");
+
+  public override void Setup() {
+    Plugin.RegisterListener<Listeners.CheckTransmit>(OnTransmit);
+    setVisibility(false);
+    base.Setup();
+  }
+
+  public override void Execute() {
+    base.Execute();
+    
+    timeElapsed = 0f;
+    setVisibility(true);
+    
+    ghostTimer = Plugin.AddTimer(1f, () => {
+      timeElapsed += 1f;
+      
+      var mod = timeElapsed % CycleDuration;
+
+      var shouldBeVisible = mod < CV_VISIBLE_DURATION.Value;
+      var timeLeft = (int)((shouldBeVisible ? 
+        CV_VISIBLE_DURATION.Value : CycleDuration) - mod);
+
+      if (shouldBeVisible != allPlayersVisible)
+        setVisibility(shouldBeVisible);
+
+      foreach (var player in PlayerUtil.GetAlive()
+       .Where(p => p?.IsValid == true)) 
+        player.PrintToCenter($"{(allPlayersVisible 
+          ? "Visible" : "Hidden")} for: {timeLeft}s");
+    }, TimerFlags.REPEAT);
+  }
+
+  private void OnTransmit(CCheckTransmitInfoList infolist) {
+    if (allPlayersVisible) return;
+
+    foreach (var (info, viewer) in infolist) {
+      if (viewer == null || !viewer.IsValid || !viewer.PawnIsAlive) continue;
+      if (viewer.TeamNum == (byte)CsTeam.Spectator) continue; // skip spec
+
+      foreach (var target in Utilities.GetPlayers()
+       .Where(target => 
+          target.IsReal() && target.Slot != viewer.Slot)) {
+        if (target.Pawn?.Value != null && target.Pawn.IsValid)
+          info.TransmitEntities.Remove(target.Pawn.Value);
+      }
+    }
+  }
+  
+  override protected HookResult OnEnd(EventRoundEnd ev, GameEventInfo info) {
+    ghostTimer?.Kill();
+    Server.ExecuteCommand("mp_footsteps_serverside 1");
+    return base.OnEnd(ev, info);
+  }
+
+  private void setVisibility(bool state) {
+    allPlayersVisible = state;
+    Server.ExecuteCommand($"mp_footsteps_serverside {(state ? "1" : "0")}");
+    if (state) EnableDamage(); else DisableDamage();
+    foreach (var player in PlayerUtil.GetAlive()) {
+      player.ExecuteClientCommand("play \"sounds/ui/counter_beep.vsnd\"");
+    }
+  }
+}

--- a/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
@@ -1,0 +1,66 @@
+using CounterStrikeSharp.API.Core;
+using Jailbreak.English.SpecialDay;
+using Jailbreak.Formatting.Extensions;
+using Jailbreak.Formatting.Views.SpecialDay;
+using Jailbreak.Public.Extensions;
+using Jailbreak.Public.Mod.SpecialDay;
+using Jailbreak.Public.Mod.SpecialDay.Enums;
+using Jailbreak.Public.Utils;
+
+namespace Jailbreak.SpecialDay.SpecialDays;
+
+public class HEDay(BasePlugin plugin, IServiceProvider provider)
+  : AbstractSpecialDay(plugin, provider) {
+  public override SDType Type => SDType.HE;
+  public override SpecialDaySettings Settings => new HESettings();
+
+  public ISDInstanceLocale Locale
+    => new SoloDayLocale("HE Only",
+      "Grenades Only—No guns. Fight against everyone else. No Camping!");
+
+  public override void Setup() {
+    plugin.RegisterEventHandler<EventGrenadeThrown>(onThrow);
+    Timers[10] += () => Locale.BeginsIn(10).ToAllChat();
+    Timers[15] += () => Locale.BeginsIn(5).ToAllChat();
+    Timers[20] += Execute;
+    
+    base.Setup();
+  }
+
+  public override void Execute() {
+    foreach (var player in PlayerUtil.GetAlive()) 
+      player.GiveNamedItem("weapon_hegrenade");
+    base.Execute();
+    Locale.BeginsIn(0).ToAllChat();
+  }
+
+  private HookResult onThrow(EventGrenadeThrown @event, GameEventInfo info) {
+    var player = @event.Userid;
+    if (player == null || !player.IsReal() || !player.PawnIsAlive)
+      return HookResult.Continue;
+    player.GiveNamedItem("weapon_hegrenade");
+    return HookResult.Continue;
+  }
+  
+  override protected HookResult
+    OnEnd(EventRoundEnd @event, GameEventInfo info) {
+    var result = base.OnEnd(@event, info);
+    Plugin.DeregisterEventHandler<EventGrenadeThrown>(onThrow);
+    return result;
+  }
+
+  public class HESettings : SpecialDaySettings {
+    public HESettings() {
+      CtTeleport   = TeleportType.RANDOM;
+      TTeleport    = TeleportType.RANDOM;
+      StripToKnife = true;
+      WithFriendlyFire();
+    }
+    
+    public override float FreezeTime(CCSPlayerController player) { return 1; }
+
+    public override ISet<string>? AllowedWeapons(CCSPlayerController player) {
+      return new HashSet<string> {"weapon_hegrenade"};
+    }
+  }
+}

--- a/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
@@ -19,7 +19,7 @@ public class HEDay(BasePlugin plugin, IServiceProvider provider)
       "Grenades Only—No guns. Fight against everyone else. No Camping!");
 
   public override void Setup() {
-    plugin.RegisterEventHandler<EventGrenadeThrown>(onThrow);
+    Plugin.RegisterEventHandler<EventGrenadeThrown>(onThrow);
     Timers[10] += () => Locale.BeginsIn(10).ToAllChat();
     Timers[15] += () => Locale.BeginsIn(5).ToAllChat();
     Timers[20] += Execute;

--- a/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/HEDay.cs
@@ -10,7 +10,7 @@ using Jailbreak.Public.Utils;
 namespace Jailbreak.SpecialDay.SpecialDays;
 
 public class HEDay(BasePlugin plugin, IServiceProvider provider)
-  : AbstractSpecialDay(plugin, provider) {
+  : AbstractSpecialDay(plugin, provider), ISpecialDayMessageProvider {
   public override SDType Type => SDType.HE;
   public override SpecialDaySettings Settings => new HESettings();
 

--- a/mod/Jailbreak.SpecialDay/SpecialDays/InfectionDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/InfectionDay.cs
@@ -120,12 +120,10 @@ public class InfectionDay(BasePlugin plugin, IServiceProvider provider)
     Plugin.DeregisterEventHandler<EventPlayerDeath>(onPlayerDeath);
     Plugin.DeregisterEventHandler<EventPlayerSpawn>(onRespawn);
 
-    Plugin.AddTimer(0.5f, () => {
-      foreach (var player in swappedPrisoners) {
-        if (player == null || !player.IsValid) continue;
-        player.SwitchTeam(CsTeam.Terrorist);
-      }
-    });
+    foreach (var player in swappedPrisoners) {
+      if (!player.IsValid) continue;
+      player.SwitchTeam(CsTeam.Terrorist);
+    }
 
     return result;
   }

--- a/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
@@ -826,6 +826,7 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
       CtTeleport = TeleportType.RANDOM_STACKED;
       TTeleport = TeleportType.RANDOM_STACKED;
       StripToKnife = true;
+      OpenCells = true;
       ConVarValues["mp_ignore_round_win_conditions"] = true;
       if (new Random().Next(3) == 0) WithAutoBhop();
       WithFriendlyFire();

--- a/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
+++ b/mod/Jailbreak.SpecialDay/SpecialDays/SpeedrunDay.cs
@@ -826,7 +826,6 @@ public class SpeedrunDay(BasePlugin plugin, IServiceProvider provider)
       CtTeleport = TeleportType.RANDOM_STACKED;
       TTeleport = TeleportType.RANDOM_STACKED;
       StripToKnife = true;
-      OpenCells = true;
       ConVarValues["mp_ignore_round_win_conditions"] = true;
       if (new Random().Next(3) == 0) WithAutoBhop();
       WithFriendlyFire();

--- a/public/Jailbreak.Public/Jailbreak.Public.csproj
+++ b/public/Jailbreak.Public/Jailbreak.Public.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.296"/>
+        <PackageReference Include="CounterStrikeSharp.API" Version="1.0.327" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.2.0"/>
         <PackageReference Include="System.Text.Json" Version="8.0.5"/>
         <ProjectReference Include="..\Jailbreak.Tag\Jailbreak.Tag.csproj"/>

--- a/public/Jailbreak.Public/Mod/SpecialDay/AbstractSpecialDay.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/AbstractSpecialDay.cs
@@ -51,7 +51,7 @@ public abstract class AbstractSpecialDay(BasePlugin plugin,
   /// </summary>
   public virtual void Setup() {
     Plugin.RegisterFakeConVars(this);
-    Plugin.RegisterEventHandler<EventRoundEnd>(OnEnd);
+    Plugin.RegisterEventHandler<EventRoundEnd>(OnEnd, HookMode.Pre);
 
     foreach (var entry in Settings.ConVarValues) {
       var cv = ConVar.Find(entry.Key);

--- a/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
@@ -38,6 +38,7 @@ public static class SDTypeExtensions {
       "speed" or "speeders" or "speedrunners" or "race" => SDType.SPEEDRUN,
       "tp"                                              => SDType.TELEPORT,
       "he" or "grenade" or "grenades"                   => SDType.HE,
+      "ghost" or "ghosts"                               => SDType.GHOST,
       _                                                 => null
     };
   }

--- a/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
@@ -10,6 +10,7 @@ public enum SDType {
   FFA,
   GUNGAME,
   GHOST,
+  HE,
   HNS,
   INFECTION,
   NOSCOPE,

--- a/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
@@ -37,6 +37,7 @@ public static class SDTypeExtensions {
       "zomb" or "zombie"                                => SDType.INFECTION,
       "speed" or "speeders" or "speedrunners" or "race" => SDType.SPEEDRUN,
       "tp"                                              => SDType.TELEPORT,
+      "he" or "grenade" or "grenades"                   => SDType.HE,
       _                                                 => null
     };
   }

--- a/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
+++ b/public/Jailbreak.Public/Mod/SpecialDay/Enums/SDType.cs
@@ -8,6 +8,7 @@ public enum SDType {
   CUSTOM,
   BHOP,
   FFA,
+  FOG,
   GUNGAME,
   GHOST,
   HE,
@@ -39,6 +40,7 @@ public static class SDTypeExtensions {
       "tp"                                              => SDType.TELEPORT,
       "he" or "grenade" or "grenades"                   => SDType.HE,
       "ghost" or "ghosts"                               => SDType.GHOST,
+      "fog"                                             => SDType.FOG,
       _                                                 => null
     };
   }


### PR DESCRIPTION
### Changelog:
- Fix: failing weapon restrictions
- Fix: infection day not maintaining the ct : t ratio
- Fix: infection day queuing people who weren't previously queued for ct
- Fix: infection day not keeping initial ct team
- Change: Hide and Seek to Old CS:GO Format
- Feat: `HE Only` Special Day
- Feat: `Ghost War` Special Day
- Feat New `Fog War` Special Day
  * FFA mode where players are surrounded by fog that grows slowly after a certain time