### PR TITLE
Bump CS2TraceRay 1.0.8 -> 1.0.9

### DIFF
--- a/mod/Jailbreak.Warden/Jailbreak.Warden.csproj
+++ b/mod/Jailbreak.Warden/Jailbreak.Warden.csproj
@@ -31,7 +31,7 @@
 
     <ItemGroup>
       <PackageReference Include="CS2ScreenMenuAPI" Version="2.6.0" />
-      <PackageReference Include="CS2TraceRay" Version="1.0.8" />
+      <PackageReference Include="CS2TraceRay" Version="1.0.9" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps the cs# dep from 1.0.8 to 1.0.9 to ensure paint to work.