### PR TITLE
Make default winner change based on round state

### DIFF
--- a/mod/Jailbreak.LastRequest/LastRequestManager.cs
+++ b/mod/Jailbreak.LastRequest/LastRequestManager.cs
@@ -175,6 +175,10 @@ public class LastRequestManager(ILRLocale messages, IServiceProvider provider)
 
       if (lastGuard is { IsLastGuardActive: true }) rebel?.UnmarkRebel(player);
       player.ExecuteClientCommandFromServer("css_lr");
+
+      var defaultWinner =
+        NativeAPI.FindConvar("mp_default_team_winner_no_objective");
+      NativeAPI.SetConvarStringValue(defaultWinner, "ct");
     }
 
     if (!shouldGrantCredits()) return;
@@ -495,6 +499,10 @@ public class LastRequestManager(ILRLocale messages, IServiceProvider provider)
     foreach (var lr in ActiveLRs.ToList())
       EndLastRequest(lr, LRResult.TIMED_OUT);
     ActiveLRs.Clear();
+
+    var defaultWinner =
+      NativeAPI.FindConvar("mp_default_team_winner_no_objective");
+    NativeAPI.SetConvarStringValue(defaultWinner, "t");
     return HookResult.Continue;
   }
 


### PR DESCRIPTION
This PR changes the default behavior of who is determined a winner in the case of no objective being valid (pertinently- when the time runs out in the round).

The original behavior has no team winning. Not only is this not necessarily accurate, but it has caused annoying issues historically with tracking the number of rounds that have passed. It is therefore generally good behavior to always have a winner.

This PR makes the **default** winners if the round ends the Terrorists; if/once Last Request has been reached, the new default is the Counter-Terrorists. The reasoning being the Warden's goal is to reach LR; once LR is reached, the CTs job could be considered completed.