### PR TITLE
fix(draw): stop CEnvBeam #4530 watchdog crash-loop (force BEAM_POINTS)

### DIFF
--- a/public/Jailbreak.Public/Mod/Draw/BeamLine.cs
+++ b/public/Jailbreak.Public/Mod/Draw/BeamLine.cs
@@ -33,6 +33,13 @@ public class BeamLine(BasePlugin plugin, Vector position, Vector end)
     Remove();
     var newBeam = Utilities.CreateEntityByName<CEnvBeam>("env_beam");
     if (newBeam == null) return;
+    // Force a pure two-point (world-space) beam. With no explicit BeamType the
+    // engine treats a code-spawned env_beam as entity-anchored and walks
+    // m_pSceneNode->m_pParent->m_pOwner to resolve a scene owner that never
+    // exists here, hanging the server's main thread in an infinite loop
+    // (Valve csgo-osx-linux #4530 "CEnvBeam infinite loop" -> watchdog kill).
+    // BEAM_POINTS draws origin->EndPos and skips that scene-owner resolution.
+    newBeam.BeamType   = BeamType_t.BEAM_POINTS;
     newBeam.RenderMode = RenderMode_t.kRenderTransAlpha;
     newBeam.Width      = width;
     newBeam.Render     = GetColor();
@@ -43,6 +50,7 @@ public class BeamLine(BasePlugin plugin, Vector position, Vector end)
     newBeam.EndPos.Z = End.Z;
     beam             = newBeam;
 
+    Utilities.SetStateChanged(newBeam, "CBeam", "m_nBeamType");
     Utilities.SetStateChanged(newBeam, "CBeam", "m_vecEndPos");
   }
 


### PR DESCRIPTION
## Problem
`cs2-jailbreak` prod is crash-looping. AcceleratorCS2 dumps show a `SIGSEGV`/`Watchdog timeout exceeded` with a **byte-identical main-thread stack across every map** — an infinite loop inside `libserver.so` `CEnvBeam` think, matching Valve [csgo-osx-linux#4530](https://github.com/ValveSoftware/csgo-osx-linux/issues/4530) *"CEnvBeam infinite loop"*.

## Root cause
`BeamLine.Draw()` creates an `env_beam` but never sets `BeamType`. With no explicit type the engine treats the code-spawned beam as **entity-anchored** and walks `m_pSceneNode->m_pParent->m_pOwner` to resolve a scene owner that never exists, hanging the main thread forever (Linux) → engine watchdog kills the process. These beams back **zones, trails, and warden markers**, so they're created every round on every map — hence the map-independent crash-loop. (RayTrace's native `DrawBeam` is disabled via `DrawBeam = 0`, so `BeamLine` is the only active `env_beam` source.)

## Fix
Set `BeamType = BeamType_t.BEAM_POINTS` — a pure origin→EndPos world-space beam that skips scene-owner resolution entirely. One-line behavioral change; all beam visuals (zones/trails/markers) keep working, minus the crash.

## Validation
- [ ] CI build green
- [ ] `:dev` server image — no CEnvBeam watchdog crash / no new Accelerator dumps across map rotation, laser visuals intact
- [ ] Promote dev→main, tag server repo, prod deploy verified